### PR TITLE
feat: add batch_size and batch_mode to data config

### DIFF
--- a/code/config/data/base.yaml
+++ b/code/config/data/base.yaml
@@ -2,3 +2,5 @@
 
 eval_every_n: 2  # Fold number for cross-validation
 seed: ${seed}  # Seed for data loader
+batch_size: null
+batch_mode: random


### PR DESCRIPTION
## Summary
- Add `batch_size` (default: null) and `batch_mode` (default: random) to shared data config `base.yaml`
- These settings are inherited by all data sources (mice, synthetic)

Closes https://github.com/AllenNeuralDynamics/aind-disrnn-pipeline/issues/16