### PR TITLE
fix: correct indentation of DE_kwargs in baseline_rl.yaml

### DIFF
--- a/code/config/model/baseline_rl.yaml
+++ b/code/config/model/baseline_rl.yaml
@@ -10,9 +10,9 @@ agent_kwargs:
   choice_kernel: "none"
   action_selection: "softmax"
 
-fit_kwargs:
-  DE_kwargs:
-    polish: true
+DE_kwargs:
+  polish: true
+  workers: 1
 
 seed: ${seed}
 


### PR DESCRIPTION
- Fix the mis-located DE_kwargs to enable multiprocessing in baselineRL fitting