### PR TITLE
feat: resumable grid launch (autoResume task per grid point)

### DIFF
--- a/code/beaker/README.md
+++ b/code/beaker/README.md
@@ -28,6 +28,9 @@ compute runs the **wrapper** image, built and maintained in
 - `experiment_scaling.yaml` — `replicas: 4`, the "array of jobs" across 4 GPUs.
 - `sweep_pack.yaml` / `experiment_pack.yaml` — GPU time-slicing benchmark (pack M
   agents on one GPU via the wrapper's `pack_gpu.sh`).
+- `launch_beaker_resumable.py` *(in `code/`)* — Option-1 **resumable** launcher:
+  expands a `method: grid` sweep into one autoResume Beaker task per grid point
+  (see "Resumable runs" below).
 
 ## Flow (dispatcher → wrapper hand-off)
 
@@ -165,3 +168,46 @@ compute or CPU (the host-bound limiter — bump `cpuCount` if so) saturates.
 > findings in the wrapper's
 > [Performance notes](https://github.com/AllenNeuralDynamics/aind-disrnn-wrapper/blob/ai_hub/beaker/README.md#performance-notes-gpu-efficiency)
 > and [benchmark figure](https://github.com/AllenNeuralDynamics/aind-disrnn-wrapper/blob/ai_hub/beaker/README.md#benchmark-figure).
+
+## Resumable runs (preemption recovery)
+
+Packed `wandb agent` sweeps (above) are *not* preemption-resilient: when a
+preemptible agent is killed mid-trial, Beaker restarts the container, the new
+agent pulls a **fresh** sweep trial, and the interrupted trial's partial
+progress is thrown away (grid coverage is preserved — wandb re-dispatches the
+cell — but the half-trained model is lost). For long runs (wide hidden sizes,
+high step counts) that wasted compute is the cost worth eliminating.
+
+`launch_beaker_resumable.py` runs a grid the resumable way instead:
+
+```bash
+WS=ai1/aind-dynamic-foraging-foundation-model
+python code/launch_beaker_resumable.py \
+  --sweep code/beaker/sweep_gru_scaling.yaml \
+  --experiment code/beaker/experiment_scaling.yaml \
+  --workspace "$WS"
+# add --no-submit to render + inspect the spec without launching
+```
+
+It expands the grid into one **self-contained Beaker task per grid point**
+(running `run_hpc` with that point's Hydra overrides baked in — no sweep
+controller), each `preemptible: true` / `priority: low`. Three things make a
+preempted task resume from its last checkpoint instead of restarting:
+
+1. **Beaker autoResume** — applied automatically to preemptible/low-priority
+   tasks (confirm with `beaker experiment spec <id>`). The restart re-runs the
+   *same* command and re-attaches the *same* `/results` dataset.
+2. **Stable output dir** — each task sets `DISRNN_RESUMABLE_OUTPUT_DIR=/results/run`
+   so `run_hpc` anchors outputs at a fixed path (not the per-run W&B dir), so the
+   restart re-finds `checkpoints/step_<N>/train_state.pkl`.
+3. **Full-state checkpoints** — the trainer writes params + optimizer + PRNG key
+   + step each checkpoint and, on startup, resumes from the highest one (the
+   wrapper's `model_trainers/checkpoint_resume.py`; gated by
+   `training.auto_resume`, default true). Requires `training.checkpoint_every_n_steps > 0`.
+
+W&B continuity across the restart is preserved by a deterministic, per-grid-point
+`WANDB_RUN_ID` + `WANDB_RESUME=allow`, with all points grouped under
+`WANDB_RUN_GROUP`.
+
+Only `method: grid` sweeps are supported — the trial set must be enumerable up
+front, since there is no sweep controller to ask for the next point.

--- a/code/beaker/README.md
+++ b/code/beaker/README.md
@@ -194,9 +194,15 @@ It expands the grid into one **self-contained Beaker task per grid point**
 controller), each `preemptible: true` / `priority: low`. Three things make a
 preempted task resume from its last checkpoint instead of restarting:
 
-1. **Beaker autoResume** — applied automatically to preemptible/low-priority
-   tasks (confirm with `beaker experiment spec <id>`). The restart re-runs the
-   *same* command and re-attaches the *same* `/results` dataset.
+1. **Beaker autoResume** — set `preemptible: true` (with `priority: low`) and the
+   server applies `autoResume: true` automatically (confirm with
+   `beaker experiment spec <id>`). Do **not** set `autoResume` explicitly in the
+   spec: the v2 schema rejects `preemptible` and `autoResume` together
+   (`Error: preemptible cannot be set with min_runtime or auto_resume`). The
+   restart re-runs the *same* command and re-attaches the *same* `/results`
+   dataset — verified live: a `beaker job preempt`ed run resumed from
+   `/results/run/outputs/checkpoints/step_300/train_state.pkl`, skipped warmup,
+   and continued with stable likelihood.
 2. **Stable output dir** — each task sets `DISRNN_RESUMABLE_OUTPUT_DIR=/results/run`
    so `run_hpc` anchors outputs at a fixed path (not the per-run W&B dir), so the
    restart re-finds `checkpoints/step_<N>/train_state.pkl`.

--- a/code/launch_beaker_resumable.py
+++ b/code/launch_beaker_resumable.py
@@ -1,0 +1,230 @@
+"""Beaker launcher for RESUMABLE grid runs (one autoResume task per grid point).
+
+This is the Option-1 alternative to ``launch_beaker.py``. Instead of creating a
+W&B *sweep* drained by packed ``wandb agent`` replicas (where a preempted trial
+is abandoned and re-run from scratch), it expands a grid sweep YAML into one
+self-contained Beaker task per grid point, each running ``run_hpc`` with the
+grid point's overrides baked in. Combined with:
+
+  * Beaker ``preemptible: true`` (the server applies ``autoResume: true`` for
+    preemptible/low-priority tasks — verified via ``beaker experiment spec``), so
+    a preempted task is restarted as the *same* task with the *same* /results,
+  * ``DISRNN_RESUMABLE_OUTPUT_DIR`` (run_hpc anchors outputs at a stable path
+    instead of the per-run W&B dir), and
+  * the trainer's full-state checkpoint/resume,
+
+a preempted run continues from its last checkpoint instead of restarting. W&B
+dashboard continuity across the restart is preserved by pinning a deterministic
+``WANDB_RUN_ID`` per grid point with ``WANDB_RESUME=allow``.
+
+Only ``method: grid`` sweeps are supported (the whole point of Option 1 — the
+trial set must be enumerable up front; there is no sweep controller to ask).
+
+Usage:
+  python code/launch_beaker_resumable.py \
+    --sweep code/beaker/sweep_gru_scaling.yaml \
+    --experiment code/beaker/experiment_scaling.yaml \
+    --workspace ai1/aind-dynamic-foraging-foundation-model
+  python code/launch_beaker_resumable.py --sweep ... --experiment ... --no-submit
+"""
+
+import argparse
+import copy
+import hashlib
+import itertools
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESULTS = Path("/results")
+
+BEAKER = shutil.which("beaker") or os.path.expanduser("~/.local/bin/beaker")
+
+# Stable path (per task's own /results dataset) where run_hpc anchors outputs so
+# autoResume restarts re-find their checkpoints. See run_hpc.py.
+RESUMABLE_OUTPUT_DIR = "/results/run"
+SWEEP_ARGS_PLACEHOLDER = "${args_no_hyphens}"
+
+
+def _git_sha(repo_dir: Path) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_dir), "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _grid_points(parameters: dict) -> list[dict[str, object]]:
+    """Cartesian product of a W&B-style grid ``parameters`` block.
+
+    Each parameter is ``{values: [...]}`` (grid axis) or ``{value: x}`` (fixed).
+    """
+    axes: list[tuple[str, list]] = []
+    for key, spec in parameters.items():
+        if not isinstance(spec, dict):
+            sys.exit(f"[resumable] parameter {key!r} must be a mapping, got {spec!r}")
+        if "values" in spec:
+            axes.append((key, list(spec["values"])))
+        elif "value" in spec:
+            axes.append((key, [spec["value"]]))
+        else:
+            sys.exit(
+                f"[resumable] parameter {key!r} needs 'values' or 'value' "
+                f"(distribution-based search is not supported in grid mode)"
+            )
+    keys = [k for k, _ in axes]
+    return [dict(zip(keys, combo)) for combo in itertools.product(*(v for _, v in axes))]
+
+
+def _override_str(key: str, value: object) -> str:
+    """Render a Hydra override ``key=value``, matching W&B's grid formatting."""
+    if isinstance(value, bool):
+        return f"{key}={str(value).lower()}"
+    return f"{key}={value}"
+
+
+def _run_id(group: str, overrides: list[str]) -> str:
+    """Deterministic W&B run id for a grid point (stable across resume)."""
+    digest = hashlib.sha1((group + "|" + "|".join(sorted(overrides))).encode()).hexdigest()
+    return f"{group}-{digest[:8]}"
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
+
+def build_spec(sweep_file: str, experiment_file: str) -> dict:
+    """Expand a grid sweep + experiment template into a multi-task Beaker spec."""
+    sweep = yaml.safe_load(Path(sweep_file).read_text())
+    if sweep.get("method") != "grid":
+        sys.exit(f"[resumable] only method: grid is supported, got {sweep.get('method')!r}")
+    base_command = sweep.get("command")
+    if not base_command or SWEEP_ARGS_PLACEHOLDER not in base_command:
+        sys.exit(
+            f"[resumable] sweep 'command' must include {SWEEP_ARGS_PLACEHOLDER} "
+            f"(the swept overrides); got {base_command!r}"
+        )
+    grid = _grid_points(sweep.get("parameters", {}))
+    if not grid:
+        sys.exit("[resumable] sweep has no grid points")
+
+    spec = yaml.safe_load(Path(experiment_file).read_text())
+    template_task = spec["tasks"][0]
+    # The bash + entrypoint.sh prefix from the template (drop its wandb-agent tail).
+    entry_prefix = list(template_task["command"][:2])
+    group = _slug(sweep.get("name", Path(sweep_file).stem))
+
+    tasks = []
+    for index, point in enumerate(grid):
+        overrides = [_override_str(k, v) for k, v in point.items()]
+        # run_hpc command = sweep base command with the placeholder expanded.
+        run_cmd: list = []
+        for token in base_command:
+            if token == SWEEP_ARGS_PLACEHOLDER:
+                run_cmd.extend(overrides)
+            else:
+                run_cmd.append(token)
+
+        task = copy.deepcopy(template_task)
+        task.pop("replicas", None)
+        task["name"] = f"{group}-{index:03d}"
+        task["command"] = entry_prefix + run_cmd
+        # Preemptible + low priority => Beaker applies autoResume (verified via
+        # `beaker experiment spec`); the restart re-uses this task's /results.
+        task["context"] = {"priority": "low", "preemptible": True}
+
+        env = [e for e in task.get("envVars", []) if e.get("name") not in {
+            "DISRNN_RESUMABLE_OUTPUT_DIR", "WANDB_RUN_ID", "WANDB_RESUME", "WANDB_RUN_GROUP",
+        }]
+        env.extend([
+            {"name": "DISRNN_RESUMABLE_OUTPUT_DIR", "value": RESUMABLE_OUTPUT_DIR},
+            {"name": "WANDB_RUN_ID", "value": _run_id(group, overrides)},
+            {"name": "WANDB_RESUME", "value": "allow"},
+            {"name": "WANDB_RUN_GROUP", "value": group},
+        ])
+        task["envVars"] = env
+        tasks.append(task)
+
+    spec["tasks"] = tasks
+    spec["description"] = f"{group} — {len(tasks)} resumable grid tasks (autoResume)"
+    return spec
+
+
+def submit(spec: dict, workspace: str, output_dir: Path) -> str | None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rendered = output_dir / "experiment_resumable_submitted.yaml"
+    rendered.write_text(yaml.safe_dump(spec, sort_keys=False))
+    print(f"[resumable] submitting {rendered.name} ({len(spec['tasks'])} tasks) to {workspace}")
+    out = subprocess.run(
+        [BEAKER, "experiment", "create", "-w", workspace, str(rendered)],
+        capture_output=True, text=True,
+    )
+    print(out.stdout + out.stderr)
+    if out.returncode != 0:
+        sys.exit(f"[resumable] `beaker experiment create` failed (exit {out.returncode})")
+    m = re.search(r"Experiment\s+(\S+)\s+submitted", out.stdout + out.stderr)
+    return m.group(1) if m else None
+
+
+def save_record(sweep_file: str, experiment_id: str | None, n_tasks: int, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(sweep_file, output_dir / Path(sweep_file).name)
+    record = {
+        "mode": "resumable-grid",
+        "n_tasks": n_tasks,
+        "experiment_id": experiment_id,
+        "experiment_url": f"https://beaker.org/ex/{experiment_id}" if experiment_id else None,
+        "dispatcher_commit": _git_sha(REPO_ROOT),
+        "sweep_file": str(sweep_file),
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    (output_dir / "beaker_resumable.json").write_text(json.dumps(record, indent=2))
+    print(f"[resumable] saved record:\n{json.dumps(record, indent=2)}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Launch a grid as one autoResume Beaker task per grid point."
+    )
+    p.add_argument("--sweep", default=str(REPO_ROOT / "code/beaker/sweep_gru_scaling.yaml"))
+    p.add_argument("--experiment", default=str(REPO_ROOT / "code/beaker/experiment_scaling.yaml"),
+                   help="experiment template providing image/cluster/resources/refs/secret")
+    p.add_argument("--workspace", default="ai1/aind-dynamic-foraging-foundation-model")
+    p.add_argument("--no-submit", action="store_true",
+                   help="render the spec + record only; don't submit to Beaker")
+    p.add_argument("--output-dir", default=str(RESULTS))
+    args = p.parse_args()
+
+    output_dir = Path(args.output_dir)
+    spec = build_spec(args.sweep, args.experiment)
+    n_tasks = len(spec["tasks"])
+    print(f"[resumable] expanded grid into {n_tasks} tasks")
+
+    experiment_id = None
+    if args.no_submit:
+        rendered = output_dir / "experiment_resumable_submitted.yaml"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        rendered.write_text(yaml.safe_dump(spec, sort_keys=False))
+        print(f"[resumable] --no-submit set; wrote {rendered}")
+    else:
+        experiment_id = submit(spec, args.workspace, output_dir)
+
+    save_record(args.sweep, experiment_id, n_tasks, output_dir)
+    print("[resumable] done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the Option-1 resumable launch path so preempted grid runs resume from their last checkpoint instead of restarting from scratch.

## What
- `code/launch_beaker_resumable.py` — expands a `method: grid` sweep into one self-contained `run_hpc` Beaker task per grid point (no sweep controller), each `preemptible: true`/`priority: low` so Beaker applies `autoResume`. Sets a stable `DISRNN_RESUMABLE_OUTPUT_DIR` and a deterministic per-point `WANDB_RUN_ID` + `WANDB_RESUME=allow`.
- `code/beaker/README.md` — "Resumable runs" section; notes that the v2 spec rejects setting `preemptible` and `autoResume` together (set `preemptible`, server applies `autoResume`).

## Why
Packed `wandb agent` sweeps abandon the interrupted trial on preemption (a new agent pulls a fresh trial). For long grid runs that wastes partial compute. This makes each grid point an autoResume unit.

## Validated
Live on Beaker: a `beaker job preempt`ed synthetic disRNN run resumed from `step_300/train_state.pkl`, skipped warmup, and continued with stable likelihood. Pairs with the wrapper PR (full-state checkpoint + resume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)