### PR TITLE
feat(data): pin mice_snapshot configs to a dated database snapshot

### DIFF
--- a/code/config/data/mice_snapshot.yaml
+++ b/code/config/data/mice_snapshot.yaml
@@ -40,6 +40,10 @@ example_max_subjects: 6                  # >=0; cap subjects used for train/eval
 #   false → return all-stage trials
 mature_only: true
 
+# Pin reads to a dated database snapshot instead of the live (growing) database,
+# so the exact same sessions/subjects are selected on every run. null -> live.
+snapshot: "20260603"
+
 # ── Curricula (task names) to include ────────────────────────────────────
 # Omit (or set to null) to use the three default foraging curricula.
 curricula:

--- a/code/config/data/mice_snapshot_scaling.yaml
+++ b/code/config/data/mice_snapshot_scaling.yaml
@@ -22,6 +22,10 @@ train_example_sessions_per_subject: 1
 eval_example_sessions_per_subject: 1
 example_max_subjects: 2
 
+# Pin reads to a dated database snapshot instead of the live (growing) database,
+# so the exact same sessions/subjects are selected on every run. null -> live.
+snapshot: "20260603"
+
 # ── Trial / feature processing ───────────────────────────────────────────
 mature_only: false            # all-stage trials (does NOT affect subject selection)
 curricula:

--- a/code/config/data/mice_snapshot_smallpool.yaml
+++ b/code/config/data/mice_snapshot_smallpool.yaml
@@ -28,6 +28,10 @@ train_example_sessions_per_subject: 1
 eval_example_sessions_per_subject: 1
 example_max_subjects: 1
 
+# Pin reads to a dated database snapshot instead of the live (growing) database,
+# so the exact same sessions/subjects are selected on every run. null -> live.
+snapshot: "20260603"
+
 # ── Trial / feature processing ───────────────────────────────────────────
 mature_only: false            # all-stage trials (does NOT affect subject selection)
 curricula:


### PR DESCRIPTION
## Summary
- Sets `snapshot: "20260603"` in `code/config/data/mice_snapshot.yaml`, `mice_snapshot_scaling.yaml`, and `mice_snapshot_smallpool.yaml` so runs select the same sessions/subjects every time instead of drifting as the live `aind-dynamic-foraging-database` grows.
- Pairs with AllenNeuralDynamics/aind-disrnn-wrapper#44, which threads the `snapshot` field through `load_mice_from_database` and every heldout/eval call site.

## Why 20260603
Verified against actual W&B runs from last week (not assumed) — see the wrapper PR for the side-by-side subject-set comparison (98-99.5% match across two independent runs).

## Deploy note
This config change alone has no effect until the Beaker image is rebuilt with the wrapper PR's dependency bump — see that PR's deploy note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)