### PR TITLE
feat(beta-scan): short-horizon (60k) length-bucketed relaunch + staged-horizon tooling

### DIFF
--- a/code/config/model/disrnn.yaml
+++ b/code/config/model/disrnn.yaml
@@ -53,6 +53,16 @@ training:
   loss_param: 1.0
   max_grad_norm: 1.0
   lambda_reg_session: 0.0   # 0 disables zero-mean session-delta regularization; try 1.0
+  # Length-bucketed batching (opt-in): trim each random-mode training batch's unroll
+  # from the global T_max to the batch's own session length, cutting padding compute.
+  # Requires data.batch_mode=random. Wired in disrnn_trainer.py (mirrors gru_scaling).
+  length_bucketing: false
+  length_bucket_grid: 128   # round session lengths up to this multiple for bucketing
+  # Extend-later: set to a prior run's W&B id to CONTINUE from its checkpoint (staged
+  # horizons). run_hpc downloads that run's training-output artifact before training so
+  # the trainer resumes from it and skips warmup. null => normal fresh run. See wrapper
+  # beaker/README.md section 3b. (env DISRNN_RESTORE_FROM_RUN_ID overrides this.)
+  restore_from_run_id: null
   checkpoint_every_n_steps: 10
   checkpoint_eval_on_eval_split: true
   checkpoint_eval_on_train_split: true

--- a/studies/beta-scan/README.md
+++ b/studies/beta-scan/README.md
@@ -36,13 +36,14 @@ as the `data-scaling-law` / `ignore-trials` D=100 arm).
 > **isolated `update_net_latent`** breakout — mean/min sigma, `n_open`, `n_closed`,
 > `frac_open` — which is the direct readout for this hypothesis (the library's aggregate
 > `update_bottlenecks_open` mixes subj+obs+latent and hides it).
-> Wrapper commit `5cb7154` (branch `feat/bottleneck-sparsity-logging`).
+> Wrapper branch `feat/bottleneck-sparsity-logging` (HEAD `87d93f8c` = sparsity logging +
+> length bucketing + extend-later restore; docs at `842f6e5`).
 
 ## Variants
 
 | variant | what differs | status | W&B group (launch) | Beaker exp |
 |---|---|---|---|---|
-| [`updnet-ratio-100mice`](variants/updnet-ratio-100mice/notes.md) | 1D update-net-ratio scan (× base β × lr × seed) at 100 mice, linear choice net | 🚧 scaffolded (not launched) | `updnet-ratio-100mice@<launch_id>` | _TBD_ |
+| [`updnet-ratio-100mice`](variants/updnet-ratio-100mice/notes.md) | 1D update-net-ratio scan (× base β × lr × seed) at 100 mice, linear choice net | ▶ **running** (short-horizon 60k, length-bucketed) | `updnet-ratio-100mice@20260703-200122` | `01KWNH6J6YV382HH35GSDWNJAE` |
 
 W&B project: **`disrnn_updnet_bottleneck_ratio_100mice`** (one project per study; one group per launch).
 
@@ -60,11 +61,24 @@ W&B project: **`disrnn_updnet_bottleneck_ratio_100mice`** (one project per study
 - **Fixed:** 100 mice (`subject_ratio=0.163`); **2-way** L/R (`ignore_policy=exclude`) to stay
   comparable to the `data-scaling-law` baseline; disRNN defaults (`latent_size=5`, update-net
   16×5) **except `choice_net_n_layers=0`** (linear choice net); scalar session conditioning
-  (pretrain 30k, warmup 20k); `n_steps=150000`; disRNN penalty warmup `n_warmup_steps=7500`
-  (~5% of n_steps); `checkpoint_every_n_steps=10000`; `snapshot=20260603`.
-- **disRNN-trainer caveat (baked into `sweep.yaml`):** the disRNN trainer has **no**
-  `early_stopping` or `length_bucketing` (those are `gru_trainer`-only). The sweep command
-  omits them — do **not** copy the `gru_scaling` sweeps verbatim.
+  (pretrain 30k, warmup 20k); disRNN penalty warmup `n_warmup_steps=7500`;
+  `checkpoint_every_n_steps=10000`; `snapshot=20260603`; batch `random`/2048 (inherited from
+  `data=mice_snapshot_scaling`).
+- **Staged horizon (this round): `n_steps=60000`** (not 150k). Rationale: get all four
+  multipliers past their bottleneck-sparsification transition to a comparable, interpretable
+  point *fast* (first full results in ~1 day, not ~3.5). `checkpoint_every_n_steps` is kept
+  small so the full resumable state uploads per run; promising cells can be **extended later**
+  to a longer horizon via `model.training.restore_from_run_id` (continues from the short run's
+  checkpoint, skips warmup — see wrapper `beaker/README.md` §3b) instead of restarting.
+- **Length-bucketed batching ON** (`model.training.length_bucketing=true`,
+  `length_bucket_grid=128`): trims each `random`-mode batch's unroll from the global
+  `T_max`≈1488 to the batch's own session length. **Measured ~1.86× throughput** on this
+  workload (2015→1083 ms/step, matched config). The disRNN trainer now supports this (wired to
+  the shared `_sample_batch`, mirroring `gru_trainer`); the disRNN config declares the keys so
+  the sweep override resolves.
+- **disRNN-trainer caveat (baked into `sweep.yaml`):** the disRNN trainer still has **no**
+  `early_stopping` (that is `gru_trainer`-only). The sweep command omits it — do **not** copy
+  the `gru_scaling` sweeps verbatim. (`length_bucketing`, formerly GRU-only, is now supported.)
 
 ## Readouts (see `analysis/`)
 

--- a/studies/beta-scan/analysis/monitor_beta_scan.py
+++ b/studies/beta-scan/analysis/monitor_beta_scan.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+"""Live monitor for the disRNN update-net-ratio beta-scan grid.
+
+Pulls the current loss + bottleneck-sparsity state for every run in the W&B
+project, grouped by the grid axes (multiplier x base-beta x lr x seed), and
+optionally renders trajectory plots for the two metrics we steer on:
+  - train/loss                                  (fit)
+  - bottlenecks/update_net_latent_frac_open     (the multiplier's direct target)
+  - bottlenecks/total_sigma                     (overall bottleneck tightness)
+
+WHY: the disRNN trainer has NO early stopping (unlike the GRU trainer, which
+stops on a loss metric). For this study we deliberately train a fixed 150k main
+steps so the sparsity-vs-multiplier comparison is at a common horizon. This
+script is the manual substitute: run it any time to see how far each run has
+progressed and whether loss AND sparsity have BOTH stabilized -- the joint
+"everything settled" condition that a future sparsity-aware early stop would key
+on. Do NOT read a loss plateau alone as "done": the bottleneck keeps closing
+(frac_open 1->0) well after loss flattens, and that closing IS the result.
+
+The `_step` axis includes the n_warmup_steps offset (default 7500): _step < 7500
+is warmup (bottlenecks held open); main training starts at _step = 7500 and runs
+to 7500 + n_steps.
+
+Sandbox-safe: uses the W&B GraphQL endpoint with WANDB_API_KEY (no wandb SDK
+login). The multiplier is consumed pre-training by resolve_disrnn_penalties and
+NOT logged directly, so it is recovered as round(update_net_latent_penalty/beta).
+
+Usage:
+    python monitor_beta_scan.py                 # print grouped status table
+    python monitor_beta_scan.py --plot          # + render trajectory PNG
+    python monitor_beta_scan.py --project NAME   # override project
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+ENTITY = "AIND-disRNN"
+DEFAULT_PROJECT = "disrnn_updnet_bottleneck_ratio_100mice"
+RUN_PREFIX = "updnet-ratio-100mice-"
+N_WARMUP_DEFAULT = 7500
+N_MAIN_TARGET = 150000
+
+METRICS = [
+    "train/loss",
+    "bottlenecks/total_sigma",
+    "bottlenecks/update_net_latent_frac_open",
+    "bottlenecks/latent_frac_open",
+]
+
+
+def _gql(query, variables):
+    key = os.environ["WANDB_API_KEY"]
+    import base64
+
+    auth = base64.b64encode(f"api:{key}".encode()).decode()
+    req = urllib.request.Request(
+        "https://api.wandb.ai/graphql",
+        data=json.dumps({"query": query, "variables": variables}).encode(),
+        headers={
+            "Authorization": f"Basic {auth}",
+            "Content-Type": "application/json",
+            "User-Agent": "beta-scan-monitor",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=90) as r:
+        return json.load(r)
+
+
+def _unwrap(v):
+    return v["value"] if isinstance(v, dict) and "value" in v else v
+
+
+def _flat(cfg):
+    c = json.loads(cfg) if isinstance(cfg, str) else (cfg or {})
+    out = {}
+
+    def rec(d, p=""):
+        for k, v in d.items():
+            v2 = _unwrap(v)
+            if isinstance(v2, dict):
+                rec(v2, p + k + ".")
+            else:
+                out[p + k] = v2
+
+    rec(c)
+    return out
+
+
+def fetch_runs(project):
+    q = """query P($e:String!,$p:String!){project(name:$p,entityName:$e){
+             runs(first:200){edges{node{name state config summaryMetrics}}}}}"""
+    data = _gql(q, {"e": ENTITY, "p": project})
+    edges = data["data"]["project"]["runs"]["edges"]
+    runs = []
+    for e in edges:
+        n = e["node"]
+        if not n["name"].startswith(RUN_PREFIX):
+            continue
+        f = _flat(n["config"])
+        s = (
+            json.loads(n["summaryMetrics"])
+            if isinstance(n["summaryMetrics"], str)
+            else (n["summaryMetrics"] or {})
+        )
+        base = f.get("model.penalties.beta")
+        unl = f.get("model.penalties.update_net_latent_penalty")
+        mult = round(unl / base) if (base and unl) else None
+        runs.append(
+            {
+                "name": n["name"],
+                "state": n["state"],
+                "mult": mult,
+                "beta": base,
+                "lr": f.get("model.training.lr"),
+                "seed": f.get("model.seed"),
+                "step": s.get("_step") or 0,
+                "loss": s.get("train/loss"),
+                "total_sigma": s.get("bottlenecks/total_sigma"),
+                "unl_frac_open": s.get("bottlenecks/update_net_latent_frac_open"),
+                "lat_frac_open": s.get("bottlenecks/latent_frac_open"),
+            }
+        )
+    return runs
+
+
+def fetch_history(project, run_name, samples=500):
+    q = """query H($p:String!,$e:String!,$n:String!,$specs:[JSONString!]!){
+             project(name:$p,entityName:$e){run(name:$n){sampledHistory(specs:$specs)}}}"""
+    spec = json.dumps({"keys": ["_step"] + METRICS, "samples": samples})
+    data = _gql(q, {"p": project, "e": ENTITY, "n": run_name, "specs": [spec]})
+    try:
+        return data["data"]["project"]["run"]["sampledHistory"][0]
+    except Exception:
+        return []
+
+
+def print_table(runs):
+    def main_step(r):
+        return max(0, (r["step"] or 0) - N_WARMUP_DEFAULT)
+
+    print(f"\n{'=' * 78}")
+    print(f"beta-scan grid: {len(runs)} runs logged")
+    by_state = {}
+    for r in runs:
+        by_state[r["state"]] = by_state.get(r["state"], 0) + 1
+    print("by state:", by_state)
+    print(f"{'=' * 78}")
+    hdr = f"{'mult':>4} {'beta':>7} {'lr':>6} {'sd':>2} | {'state':8} {'_step':>7} {'main%':>6} | {'loss':>6} {'totσ':>6} {'unl_open':>8} {'lat_open':>8}"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in sorted(runs, key=lambda x: (x["mult"] or 0, x["beta"] or 0, x["lr"] or 0, x["seed"] or 0)):
+        pct = 100.0 * main_step(r) / N_MAIN_TARGET
+
+        def fmt(v, f="{:.3f}"):
+            return f.format(v) if isinstance(v, (int, float)) else "  -  "
+
+        flag = " <-- FAILED" if r["state"] == "failed" else ""
+        print(
+            f"{str(r['mult']):>4} {str(r['beta']):>7} {str(r['lr']):>6} {str(r['seed']):>2} | "
+            f"{r['state']:8} {r['step']:7d} {pct:5.1f}% | "
+            f"{fmt(r['loss'])} {fmt(r['total_sigma'],'{:.2f}')} {fmt(r['unl_frac_open'],'{:.2f}'):>8} {fmt(r['lat_frac_open'],'{:.2f}'):>8}{flag}"
+        )
+    # failures summary
+    fails = [r for r in runs if r["state"] == "failed"]
+    if fails:
+        print(f"\n{len(fails)} FAILED (likely NaN in high-lr corner):")
+        for r in fails:
+            print(f"  mult={r['mult']} beta={r['beta']} lr={r['lr']} seed={r['seed']} (died at _step={r['step']})")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project", default=DEFAULT_PROJECT)
+    ap.add_argument("--plot", action="store_true")
+    ap.add_argument("--out", default="beta_scan_monitor.png")
+    args = ap.parse_args()
+
+    runs = fetch_runs(args.project)
+    if not runs:
+        print(f"No runs found in {ENTITY}/{args.project}")
+        return
+    print_table(runs)
+
+    if args.plot:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        # runs with a real trajectory
+        traj = [r for r in runs if (r["step"] or 0) > N_WARMUP_DEFAULT + 200]
+        traj = sorted(traj, key=lambda x: -(x["step"] or 0))[:12]
+        if not traj:
+            print("\n(no run far enough into main training to plot yet)")
+            return
+        hist = {r["name"]: fetch_history(args.project, r["name"]) for r in traj}
+        fig, axes = plt.subplots(1, 3, figsize=(13, 3.8))
+        plot_metrics = [
+            ("train/loss", "Training loss", "loss (lower=better)"),
+            ("bottlenecks/total_sigma", "Total bottleneck sigma", "total sigma"),
+            ("bottlenecks/update_net_latent_frac_open", "Update-net latent frac open", "frac open (1=open)"),
+        ]
+        colors = plt.cm.viridis(np.linspace(0.1, 0.9, len(traj)))
+        for ax, (key, title, ylab) in zip(axes, plot_metrics):
+            for r, c in zip(traj, colors):
+                rows = hist.get(r["name"], [])
+                xy = [(rr.get("_step"), rr.get(key)) for rr in rows if rr.get("_step") is not None and rr.get(key) is not None]
+                if xy:
+                    x, y = zip(*xy)
+                    ax.plot(x, y, color=c, lw=1.3, label=f"m{r['mult']} b{r['beta']} lr{r['lr']} s{r['seed']}")
+            ax.axvline(N_WARMUP_DEFAULT, color="0.7", ls="--", lw=0.8)
+            ax.set_title(title)
+            ax.set_xlabel("wandb _step (warmup<7500)")
+            ax.set_ylabel(ylab)
+            ax.margins(0.04)
+        axes[0].legend(fontsize=5.5, frameon=False)
+        fig.suptitle(f"beta-scan monitor: loss vs sparsity ({len(traj)} runs)", y=1.02)
+        fig.tight_layout()
+        fig.savefig(args.out, dpi=140, bbox_inches="tight")
+        print(f"\nsaved plot -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/studies/beta-scan/variants/smoke/experiment.yaml
+++ b/studies/beta-scan/variants/smoke/experiment.yaml
@@ -34,7 +34,7 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf   # real-time bottleneck-sparsity logging
+        value: 87d93f8c989e2059b67c1e87c137f799103ada77   # + length bucketing + extend-later restore
       - name: DISPATCHER_REF
         value: feat/beta-scan                              # this study's code/config source
       # (online by default; safeguard auto-falls-back to offline on a flaky init)

--- a/studies/beta-scan/variants/smoke/launch_record/beaker_resumable.json
+++ b/studies/beta-scan/variants/smoke/launch_record/beaker_resumable.json
@@ -1,9 +1,9 @@
 {
   "mode": "resumable-grid",
   "n_tasks": 1,
-  "experiment_id": "01KWMX6Y16KJM2MKZ9RPDZVJYC",
-  "experiment_url": "https://beaker.org/ex/01KWMX6Y16KJM2MKZ9RPDZVJYC",
-  "dispatcher_commit": "3b96e8ee75089c23a6df2d1d04ae62794415db9b",
+  "experiment_id": null,
+  "experiment_url": null,
+  "dispatcher_commit": "88f652f70d036a32390ba3c8dcd920ed0042c5c1",
   "sweep_file": "studies/beta-scan/variants/smoke/sweep.yaml",
-  "created_utc": "2026-07-03T21:12:32.807223+00:00"
+  "created_utc": "2026-07-04T02:10:03.917568+00:00"
 }

--- a/studies/beta-scan/variants/smoke/launch_record/experiment_resumable_submitted.yaml
+++ b/studies/beta-scan/variants/smoke/launch_record/experiment_resumable_submitted.yaml
@@ -1,7 +1,7 @@
 version: v2
-description: "smoke@20260703-141230 \u2014 1 resumable grid tasks (autoResume)"
+description: "smoke@20260703-191003 \u2014 1 resumable grid tasks (autoResume)"
 tasks:
-- name: smoke-20260703-141230-000
+- name: smoke-20260703-191003-000
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -22,10 +22,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=2000
   - model.architecture.session_n_warmup_steps=1000
-  - model.training.n_steps=6000
+  - model.training.n_steps=4000
   - model.training.n_warmup_steps=500
-  - model.training.checkpoint_every_n_steps=2000
+  - model.training.checkpoint_every_n_steps=1000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -41,30 +43,29 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: smoke-20260703-141230-0bb97dc7
+    value: smoke-20260703-191003-561b78c0
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: smoke@20260703-141230
+    value: smoke@20260703-191003
   - name: DISRNN_META_STUDY
     value: beta-scan
   - name: DISRNN_META_VARIANT
     value: smoke
   - name: DISRNN_META_LAUNCH_ID
-    value: 20260703-141230
+    value: 20260703-191003
   - name: DISRNN_META_CONFIG_HASH
-    value: e0da6f0c
+    value: 5037e61f
   - name: DISRNN_META_LABEL
-    value: beta-scan-smoke
+    value: smoke-lengthbucket
   - name: DISRNN_META_NOTE
-    value: 'smoke v3: verify step-0 sparsity baseline + loss-pace bottlenecks/* logging
-      (wrapper eaca1a0)'
+    value: 'smoke: verify length_bucketing trims unroll + resumable ckpt for extend-later'
   result:
     path: /results
   context:

--- a/studies/beta-scan/variants/smoke/launch_record/sweep.yaml
+++ b/studies/beta-scan/variants/smoke/launch_record/sweep.yaml
@@ -26,10 +26,12 @@ command:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=2000
   - model.architecture.session_n_warmup_steps=1000
-  - model.training.n_steps=6000
+  - model.training.n_steps=4000
   - model.training.n_warmup_steps=500
-  - model.training.checkpoint_every_n_steps=2000
+  - model.training.checkpoint_every_n_steps=1000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - ${args_no_hyphens}
 parameters:
   model.penalties.update_net_latent_penalty_multiplier:

--- a/studies/beta-scan/variants/smoke/sweep.yaml
+++ b/studies/beta-scan/variants/smoke/sweep.yaml
@@ -26,10 +26,12 @@ command:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=2000
   - model.architecture.session_n_warmup_steps=1000
-  - model.training.n_steps=6000
+  - model.training.n_steps=4000
   - model.training.n_warmup_steps=500
-  - model.training.checkpoint_every_n_steps=2000
+  - model.training.checkpoint_every_n_steps=1000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - ${args_no_hyphens}
 parameters:
   model.penalties.update_net_latent_penalty_multiplier:

--- a/studies/beta-scan/variants/updnet-ratio-100mice/experiment.yaml
+++ b/studies/beta-scan/variants/updnet-ratio-100mice/experiment.yaml
@@ -7,9 +7,10 @@
 # L40S, so route to g6e (one 90GiB / 12-CPU bundle), NOT octo-hub-onprem-h200. Keeping it
 # off H200 also avoids contending with the running ignore-trials nxd-3way grid there.
 #
-# WRAPPER_REF is pinned to the bottleneck-sparsity-logging commit so each run logs the
-# real-time bottlenecks/* scalars (incl. the isolated update_net_latent channel). The
-# entrypoint git-pulls this at container startup — no image rebuild needed (code-only edit).
+# WRAPPER_REF is pinned to the bottleneck-sparsity-logging branch commit that carries:
+# real-time bottlenecks/* scalars (incl. the isolated update_net_latent channel), disRNN
+# length-bucketed batching, and the extend-later checkpoint-restore path. The entrypoint
+# git-pulls this at container startup — no image rebuild needed (code-only edits).
 version: v2
 description: >
   beta-scan updnet-ratio-100mice — 48-task grid over update_net_latent_penalty_multiplier
@@ -34,7 +35,7 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf   # real-time bottleneck-sparsity logging
+        value: 87d93f8c989e2059b67c1e87c137f799103ada77   # + length bucketing + extend-later restore
       - name: DISPATCHER_REF
         value: feat/beta-scan                              # this study's code/config source
       # (online by default; safeguard auto-falls-back to offline on a flaky init)

--- a/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/beaker_resumable.json
+++ b/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/beaker_resumable.json
@@ -1,10 +1,9 @@
 {
   "mode": "resumable-grid",
   "n_tasks": 48,
-  "experiment_id": "01KWMXQDX0CVESEFYP3A4EM2PC",
-  "experiment_url": "https://beaker.org/ex/01KWMXQDX0CVESEFYP3A4EM2PC",
-  "dispatcher_commit": "3b96e8ee75089c23a6df2d1d04ae62794415db9b",
+  "experiment_id": null,
+  "experiment_url": null,
+  "dispatcher_commit": "06bb5a3158131eb52c39a78da7e9cb4885842483",
   "sweep_file": "studies/beta-scan/variants/updnet-ratio-100mice/sweep.yaml",
-  "created_utc": "2026-07-03T21:20:20.093442+00:00",
-  "note": "full 48-run grid; W&B project disrnn_updnet_bottleneck_ratio_100mice; wrapper eaca1a0 (loss-pace sparsity + step-0 baseline); submitted via extended-timeout client (launcher 5s create timeout on 48-task POST)"
+  "created_utc": "2026-07-04T02:07:45.647296+00:00"
 }

--- a/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/beaker_resumable.json
+++ b/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/beaker_resumable.json
@@ -1,9 +1,9 @@
 {
   "mode": "resumable-grid",
   "n_tasks": 48,
-  "experiment_id": null,
-  "experiment_url": null,
-  "dispatcher_commit": "06bb5a3158131eb52c39a78da7e9cb4885842483",
+  "experiment_id": "01KWNH6J6YV382HH35GSDWNJAE",
+  "experiment_url": "https://beaker.org/ex/01KWNH6J6YV382HH35GSDWNJAE",
+  "dispatcher_commit": "f7f750692e6ed7c071457b4e63fb0cd8a06d040c",
   "sweep_file": "studies/beta-scan/variants/updnet-ratio-100mice/sweep.yaml",
-  "created_utc": "2026-07-04T02:07:45.647296+00:00"
+  "created_utc": "2026-07-04T03:01:22.329816+00:00"
 }

--- a/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/experiment_resumable_submitted.yaml
+++ b/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/experiment_resumable_submitted.yaml
@@ -1,8 +1,8 @@
 version: v2
-description: "updnet-ratio-100mice@20260703-190745 \u2014 48 resumable grid tasks\
+description: "updnet-ratio-100mice@20260703-200122 \u2014 48 resumable grid tasks\
   \ (autoResume)"
 tasks:
-- name: updnet-ratio-100mice-20260703-190745-000
+- name: updnet-ratio-100mice-20260703-200122-000
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -50,11 +50,11 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-9190af56
+    value: updnet-ratio-100mice-20260703-200122-8646dfc2
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - &id001
     name: DISRNN_META_STUDY
     value: beta-scan
@@ -63,19 +63,23 @@ tasks:
     value: updnet-ratio-100mice
   - &id003
     name: DISRNN_META_LAUNCH_ID
-    value: 20260703-190745
+    value: 20260703-200122
   - &id004
     name: DISRNN_META_CONFIG_HASH
     value: 6d28f4ff
   - &id005
     name: DISRNN_META_LABEL
     value: updnet-ratio-100mice
+  - &id006
+    name: DISRNN_META_NOTE
+    value: 'short-horizon (60k) relaunch: length_bucketing on (~1.86x), random/2048,
+      extend-later ready'
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-001
+- name: updnet-ratio-100mice-20260703-200122-001
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -123,22 +127,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-09c8a64b
+    value: updnet-ratio-100mice-20260703-200122-9703d37e
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-002
+- name: updnet-ratio-100mice-20260703-200122-002
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -186,22 +191,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-53f8b417
+    value: updnet-ratio-100mice-20260703-200122-61873594
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-003
+- name: updnet-ratio-100mice-20260703-200122-003
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -249,22 +255,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-752efb91
+    value: updnet-ratio-100mice-20260703-200122-c74f4556
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-004
+- name: updnet-ratio-100mice-20260703-200122-004
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -312,22 +319,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-5e30c044
+    value: updnet-ratio-100mice-20260703-200122-87018bd0
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-005
+- name: updnet-ratio-100mice-20260703-200122-005
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -375,22 +383,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-00513da3
+    value: updnet-ratio-100mice-20260703-200122-c4294c47
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-006
+- name: updnet-ratio-100mice-20260703-200122-006
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -438,22 +447,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-6236e3c7
+    value: updnet-ratio-100mice-20260703-200122-ccab8055
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-007
+- name: updnet-ratio-100mice-20260703-200122-007
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -501,22 +511,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-29d75ef2
+    value: updnet-ratio-100mice-20260703-200122-a1395e7f
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-008
+- name: updnet-ratio-100mice-20260703-200122-008
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -564,22 +575,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-eab4c56e
+    value: updnet-ratio-100mice-20260703-200122-a9972d14
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-009
+- name: updnet-ratio-100mice-20260703-200122-009
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -627,22 +639,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-5d54f36c
+    value: updnet-ratio-100mice-20260703-200122-81796eba
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-010
+- name: updnet-ratio-100mice-20260703-200122-010
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -690,22 +703,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-672ca70f
+    value: updnet-ratio-100mice-20260703-200122-6726abbb
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-011
+- name: updnet-ratio-100mice-20260703-200122-011
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -753,22 +767,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-e134f27f
+    value: updnet-ratio-100mice-20260703-200122-418e7d2d
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-012
+- name: updnet-ratio-100mice-20260703-200122-012
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -816,22 +831,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-bd0178fe
+    value: updnet-ratio-100mice-20260703-200122-1ad83f71
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-013
+- name: updnet-ratio-100mice-20260703-200122-013
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -879,22 +895,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-575f16c1
+    value: updnet-ratio-100mice-20260703-200122-3dcb9217
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-014
+- name: updnet-ratio-100mice-20260703-200122-014
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -942,22 +959,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-7c1375dc
+    value: updnet-ratio-100mice-20260703-200122-c165b687
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-015
+- name: updnet-ratio-100mice-20260703-200122-015
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1005,22 +1023,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-a4fe345e
+    value: updnet-ratio-100mice-20260703-200122-2408e539
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-016
+- name: updnet-ratio-100mice-20260703-200122-016
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1068,22 +1087,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-ca4271c5
+    value: updnet-ratio-100mice-20260703-200122-2fea9734
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-017
+- name: updnet-ratio-100mice-20260703-200122-017
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1131,22 +1151,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-4dda9dd7
+    value: updnet-ratio-100mice-20260703-200122-46df8297
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-018
+- name: updnet-ratio-100mice-20260703-200122-018
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1194,22 +1215,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-10182509
+    value: updnet-ratio-100mice-20260703-200122-0d674875
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-019
+- name: updnet-ratio-100mice-20260703-200122-019
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1257,22 +1279,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-39c9b10d
+    value: updnet-ratio-100mice-20260703-200122-686d58ad
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-020
+- name: updnet-ratio-100mice-20260703-200122-020
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1320,22 +1343,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-28446f7e
+    value: updnet-ratio-100mice-20260703-200122-6d32af0d
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-021
+- name: updnet-ratio-100mice-20260703-200122-021
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1383,22 +1407,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-3bfa3a54
+    value: updnet-ratio-100mice-20260703-200122-006ba610
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-022
+- name: updnet-ratio-100mice-20260703-200122-022
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1446,22 +1471,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-56137c4d
+    value: updnet-ratio-100mice-20260703-200122-ced0f761
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-023
+- name: updnet-ratio-100mice-20260703-200122-023
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1509,22 +1535,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-2f38a563
+    value: updnet-ratio-100mice-20260703-200122-45646c46
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-024
+- name: updnet-ratio-100mice-20260703-200122-024
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1572,22 +1599,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-9924fc49
+    value: updnet-ratio-100mice-20260703-200122-f51ea643
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-025
+- name: updnet-ratio-100mice-20260703-200122-025
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1635,22 +1663,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-3d10d0f1
+    value: updnet-ratio-100mice-20260703-200122-da46c05a
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-026
+- name: updnet-ratio-100mice-20260703-200122-026
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1698,22 +1727,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-29f657f0
+    value: updnet-ratio-100mice-20260703-200122-cace9bc8
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-027
+- name: updnet-ratio-100mice-20260703-200122-027
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1761,22 +1791,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-220e7c34
+    value: updnet-ratio-100mice-20260703-200122-e33962db
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-028
+- name: updnet-ratio-100mice-20260703-200122-028
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1824,22 +1855,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-e7abb6a4
+    value: updnet-ratio-100mice-20260703-200122-4c2635cc
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-029
+- name: updnet-ratio-100mice-20260703-200122-029
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1887,22 +1919,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-a5732ef1
+    value: updnet-ratio-100mice-20260703-200122-159eea2e
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-030
+- name: updnet-ratio-100mice-20260703-200122-030
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1950,22 +1983,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-803e2a0c
+    value: updnet-ratio-100mice-20260703-200122-87f84a2e
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-031
+- name: updnet-ratio-100mice-20260703-200122-031
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2013,22 +2047,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-bd68620a
+    value: updnet-ratio-100mice-20260703-200122-8d9faa61
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-032
+- name: updnet-ratio-100mice-20260703-200122-032
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2076,22 +2111,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-d2ebe8ff
+    value: updnet-ratio-100mice-20260703-200122-2c1d2ef5
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-033
+- name: updnet-ratio-100mice-20260703-200122-033
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2139,22 +2175,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-0ca19a22
+    value: updnet-ratio-100mice-20260703-200122-c0d18a94
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-034
+- name: updnet-ratio-100mice-20260703-200122-034
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2202,22 +2239,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-6889c41d
+    value: updnet-ratio-100mice-20260703-200122-a1e95d8c
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-035
+- name: updnet-ratio-100mice-20260703-200122-035
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2265,22 +2303,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-d42e6257
+    value: updnet-ratio-100mice-20260703-200122-81a9f5f2
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-036
+- name: updnet-ratio-100mice-20260703-200122-036
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2328,22 +2367,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-a74f6bc8
+    value: updnet-ratio-100mice-20260703-200122-07fc89ee
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-037
+- name: updnet-ratio-100mice-20260703-200122-037
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2391,22 +2431,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-c52e6821
+    value: updnet-ratio-100mice-20260703-200122-0e8f2910
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-038
+- name: updnet-ratio-100mice-20260703-200122-038
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2454,22 +2495,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-75951c4d
+    value: updnet-ratio-100mice-20260703-200122-76a5cbb7
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-039
+- name: updnet-ratio-100mice-20260703-200122-039
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2517,22 +2559,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-835f73bb
+    value: updnet-ratio-100mice-20260703-200122-25cebd13
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-040
+- name: updnet-ratio-100mice-20260703-200122-040
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2580,22 +2623,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-3315aee1
+    value: updnet-ratio-100mice-20260703-200122-fbb24a93
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-041
+- name: updnet-ratio-100mice-20260703-200122-041
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2643,22 +2687,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-54272cc8
+    value: updnet-ratio-100mice-20260703-200122-ececb4c7
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-042
+- name: updnet-ratio-100mice-20260703-200122-042
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2706,22 +2751,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-db1a2af8
+    value: updnet-ratio-100mice-20260703-200122-1fac96c7
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-043
+- name: updnet-ratio-100mice-20260703-200122-043
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2769,22 +2815,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-dd277415
+    value: updnet-ratio-100mice-20260703-200122-04073e9f
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-044
+- name: updnet-ratio-100mice-20260703-200122-044
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2832,22 +2879,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-238e20a0
+    value: updnet-ratio-100mice-20260703-200122-86a5a56f
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-045
+- name: updnet-ratio-100mice-20260703-200122-045
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2895,22 +2943,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-3df0abad
+    value: updnet-ratio-100mice-20260703-200122-72fb26ca
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-046
+- name: updnet-ratio-100mice-20260703-200122-046
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2958,22 +3007,23 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-48ff99c4
+    value: updnet-ratio-100mice-20260703-200122-13797a5c
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-190745-047
+- name: updnet-ratio-100mice-20260703-200122-047
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -3021,16 +3071,17 @@ tasks:
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-190745-afe0403e
+    value: updnet-ratio-100mice-20260703-200122-88af2b77
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-190745
+    value: updnet-ratio-100mice@20260703-200122
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
+  - *id006
   result:
     path: /results
   context:

--- a/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/experiment_resumable_submitted.yaml
+++ b/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/experiment_resumable_submitted.yaml
@@ -1,8 +1,8 @@
 version: v2
-description: "updnet-ratio-100mice@20260703-142019 \u2014 48 resumable grid tasks\
+description: "updnet-ratio-100mice@20260703-190745 \u2014 48 resumable grid tasks\
   \ (autoResume)"
 tasks:
-- name: updnet-ratio-100mice-20260703-142019-000
+- name: updnet-ratio-100mice-20260703-190745-000
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -23,10 +23,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=3e-4
   - model.training.lr=1e-3
@@ -42,17 +44,17 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-f707aa78
+    value: updnet-ratio-100mice-20260703-190745-9190af56
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - &id001
     name: DISRNN_META_STUDY
     value: beta-scan
@@ -61,23 +63,19 @@ tasks:
     value: updnet-ratio-100mice
   - &id003
     name: DISRNN_META_LAUNCH_ID
-    value: 20260703-142019
+    value: 20260703-190745
   - &id004
     name: DISRNN_META_CONFIG_HASH
-    value: 1a5cb3e6
+    value: 6d28f4ff
   - &id005
     name: DISRNN_META_LABEL
     value: updnet-ratio-100mice
-  - &id006
-    name: DISRNN_META_NOTE
-    value: update-net latent penalty ratio scan @100 mice, linear choice net; sparsity
-      at loss pace + step-0 baseline (wrapper eaca1a0)
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-001
+- name: updnet-ratio-100mice-20260703-190745-001
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -98,10 +96,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=3e-4
   - model.training.lr=1e-3
@@ -117,29 +117,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-14d1c216
+    value: updnet-ratio-100mice-20260703-190745-09c8a64b
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-002
+- name: updnet-ratio-100mice-20260703-190745-002
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -160,10 +159,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=3e-4
   - model.training.lr=5e-3
@@ -179,29 +180,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-0272a098
+    value: updnet-ratio-100mice-20260703-190745-53f8b417
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-003
+- name: updnet-ratio-100mice-20260703-190745-003
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -222,10 +222,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=3e-4
   - model.training.lr=5e-3
@@ -241,29 +243,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-50c15b78
+    value: updnet-ratio-100mice-20260703-190745-752efb91
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-004
+- name: updnet-ratio-100mice-20260703-190745-004
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -284,10 +285,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -303,29 +306,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-5877a03f
+    value: updnet-ratio-100mice-20260703-190745-5e30c044
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-005
+- name: updnet-ratio-100mice-20260703-190745-005
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -346,10 +348,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -365,29 +369,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-ff372f68
+    value: updnet-ratio-100mice-20260703-190745-00513da3
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-006
+- name: updnet-ratio-100mice-20260703-190745-006
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -408,10 +411,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=1e-3
   - model.training.lr=5e-3
@@ -427,29 +432,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-93a46f3d
+    value: updnet-ratio-100mice-20260703-190745-6236e3c7
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-007
+- name: updnet-ratio-100mice-20260703-190745-007
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -470,10 +474,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=1e-3
   - model.training.lr=5e-3
@@ -489,29 +495,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-f72121dd
+    value: updnet-ratio-100mice-20260703-190745-29d75ef2
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-008
+- name: updnet-ratio-100mice-20260703-190745-008
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -532,10 +537,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=3e-3
   - model.training.lr=1e-3
@@ -551,29 +558,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-53db4a06
+    value: updnet-ratio-100mice-20260703-190745-eab4c56e
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-009
+- name: updnet-ratio-100mice-20260703-190745-009
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -594,10 +600,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=3e-3
   - model.training.lr=1e-3
@@ -613,29 +621,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-f361f6ed
+    value: updnet-ratio-100mice-20260703-190745-5d54f36c
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-010
+- name: updnet-ratio-100mice-20260703-190745-010
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -656,10 +663,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=3e-3
   - model.training.lr=5e-3
@@ -675,29 +684,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-e081b7bd
+    value: updnet-ratio-100mice-20260703-190745-672ca70f
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-011
+- name: updnet-ratio-100mice-20260703-190745-011
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -718,10 +726,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=1
   - model.penalties.beta=3e-3
   - model.training.lr=5e-3
@@ -737,29 +747,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-b0d8fefe
+    value: updnet-ratio-100mice-20260703-190745-e134f27f
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-012
+- name: updnet-ratio-100mice-20260703-190745-012
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -780,10 +789,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=3e-4
   - model.training.lr=1e-3
@@ -799,29 +810,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-29c8327a
+    value: updnet-ratio-100mice-20260703-190745-bd0178fe
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-013
+- name: updnet-ratio-100mice-20260703-190745-013
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -842,10 +852,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=3e-4
   - model.training.lr=1e-3
@@ -861,29 +873,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-c65603ad
+    value: updnet-ratio-100mice-20260703-190745-575f16c1
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-014
+- name: updnet-ratio-100mice-20260703-190745-014
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -904,10 +915,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=3e-4
   - model.training.lr=5e-3
@@ -923,29 +936,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-54953a7a
+    value: updnet-ratio-100mice-20260703-190745-7c1375dc
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-015
+- name: updnet-ratio-100mice-20260703-190745-015
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -966,10 +978,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=3e-4
   - model.training.lr=5e-3
@@ -985,29 +999,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-f841f2e2
+    value: updnet-ratio-100mice-20260703-190745-a4fe345e
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-016
+- name: updnet-ratio-100mice-20260703-190745-016
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1028,10 +1041,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -1047,29 +1062,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-57d6b9f9
+    value: updnet-ratio-100mice-20260703-190745-ca4271c5
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-017
+- name: updnet-ratio-100mice-20260703-190745-017
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1090,10 +1104,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -1109,29 +1125,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-a9e78d8e
+    value: updnet-ratio-100mice-20260703-190745-4dda9dd7
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-018
+- name: updnet-ratio-100mice-20260703-190745-018
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1152,10 +1167,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=1e-3
   - model.training.lr=5e-3
@@ -1171,29 +1188,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-887f3066
+    value: updnet-ratio-100mice-20260703-190745-10182509
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-019
+- name: updnet-ratio-100mice-20260703-190745-019
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1214,10 +1230,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=1e-3
   - model.training.lr=5e-3
@@ -1233,29 +1251,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-3a374785
+    value: updnet-ratio-100mice-20260703-190745-39c9b10d
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-020
+- name: updnet-ratio-100mice-20260703-190745-020
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1276,10 +1293,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=3e-3
   - model.training.lr=1e-3
@@ -1295,29 +1314,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-ac10eae5
+    value: updnet-ratio-100mice-20260703-190745-28446f7e
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-021
+- name: updnet-ratio-100mice-20260703-190745-021
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1338,10 +1356,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=3e-3
   - model.training.lr=1e-3
@@ -1357,29 +1377,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-f4bd44c6
+    value: updnet-ratio-100mice-20260703-190745-3bfa3a54
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-022
+- name: updnet-ratio-100mice-20260703-190745-022
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1400,10 +1419,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=3e-3
   - model.training.lr=5e-3
@@ -1419,29 +1440,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-05eed955
+    value: updnet-ratio-100mice-20260703-190745-56137c4d
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-023
+- name: updnet-ratio-100mice-20260703-190745-023
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1462,10 +1482,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=2
   - model.penalties.beta=3e-3
   - model.training.lr=5e-3
@@ -1481,29 +1503,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-db2f385a
+    value: updnet-ratio-100mice-20260703-190745-2f38a563
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-024
+- name: updnet-ratio-100mice-20260703-190745-024
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1524,10 +1545,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=3e-4
   - model.training.lr=1e-3
@@ -1543,29 +1566,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-0324904a
+    value: updnet-ratio-100mice-20260703-190745-9924fc49
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-025
+- name: updnet-ratio-100mice-20260703-190745-025
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1586,10 +1608,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=3e-4
   - model.training.lr=1e-3
@@ -1605,29 +1629,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-b53294d2
+    value: updnet-ratio-100mice-20260703-190745-3d10d0f1
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-026
+- name: updnet-ratio-100mice-20260703-190745-026
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1648,10 +1671,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=3e-4
   - model.training.lr=5e-3
@@ -1667,29 +1692,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-cc827a97
+    value: updnet-ratio-100mice-20260703-190745-29f657f0
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-027
+- name: updnet-ratio-100mice-20260703-190745-027
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1710,10 +1734,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=3e-4
   - model.training.lr=5e-3
@@ -1729,29 +1755,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-f229b190
+    value: updnet-ratio-100mice-20260703-190745-220e7c34
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-028
+- name: updnet-ratio-100mice-20260703-190745-028
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1772,10 +1797,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -1791,29 +1818,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-9920efa3
+    value: updnet-ratio-100mice-20260703-190745-e7abb6a4
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-029
+- name: updnet-ratio-100mice-20260703-190745-029
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1834,10 +1860,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -1853,29 +1881,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-adbf594c
+    value: updnet-ratio-100mice-20260703-190745-a5732ef1
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-030
+- name: updnet-ratio-100mice-20260703-190745-030
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1896,10 +1923,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=1e-3
   - model.training.lr=5e-3
@@ -1915,29 +1944,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-314cfb51
+    value: updnet-ratio-100mice-20260703-190745-803e2a0c
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-031
+- name: updnet-ratio-100mice-20260703-190745-031
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -1958,10 +1986,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=1e-3
   - model.training.lr=5e-3
@@ -1977,29 +2007,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-a233aa76
+    value: updnet-ratio-100mice-20260703-190745-bd68620a
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-032
+- name: updnet-ratio-100mice-20260703-190745-032
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2020,10 +2049,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=3e-3
   - model.training.lr=1e-3
@@ -2039,29 +2070,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-eaef4dd8
+    value: updnet-ratio-100mice-20260703-190745-d2ebe8ff
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-033
+- name: updnet-ratio-100mice-20260703-190745-033
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2082,10 +2112,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=3e-3
   - model.training.lr=1e-3
@@ -2101,29 +2133,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-34f4b178
+    value: updnet-ratio-100mice-20260703-190745-0ca19a22
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-034
+- name: updnet-ratio-100mice-20260703-190745-034
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2144,10 +2175,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=3e-3
   - model.training.lr=5e-3
@@ -2163,29 +2196,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-28b49cff
+    value: updnet-ratio-100mice-20260703-190745-6889c41d
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-035
+- name: updnet-ratio-100mice-20260703-190745-035
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2206,10 +2238,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=5
   - model.penalties.beta=3e-3
   - model.training.lr=5e-3
@@ -2225,29 +2259,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-6ce8d3e8
+    value: updnet-ratio-100mice-20260703-190745-d42e6257
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-036
+- name: updnet-ratio-100mice-20260703-190745-036
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2268,10 +2301,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=3e-4
   - model.training.lr=1e-3
@@ -2287,29 +2322,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-da0a326d
+    value: updnet-ratio-100mice-20260703-190745-a74f6bc8
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-037
+- name: updnet-ratio-100mice-20260703-190745-037
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2330,10 +2364,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=3e-4
   - model.training.lr=1e-3
@@ -2349,29 +2385,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-9f9d160d
+    value: updnet-ratio-100mice-20260703-190745-c52e6821
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-038
+- name: updnet-ratio-100mice-20260703-190745-038
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2392,10 +2427,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=3e-4
   - model.training.lr=5e-3
@@ -2411,29 +2448,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-085b3d17
+    value: updnet-ratio-100mice-20260703-190745-75951c4d
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-039
+- name: updnet-ratio-100mice-20260703-190745-039
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2454,10 +2490,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=3e-4
   - model.training.lr=5e-3
@@ -2473,29 +2511,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-5807f538
+    value: updnet-ratio-100mice-20260703-190745-835f73bb
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-040
+- name: updnet-ratio-100mice-20260703-190745-040
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2516,10 +2553,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -2535,29 +2574,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-a0f219e2
+    value: updnet-ratio-100mice-20260703-190745-3315aee1
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-041
+- name: updnet-ratio-100mice-20260703-190745-041
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2578,10 +2616,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=1e-3
   - model.training.lr=1e-3
@@ -2597,29 +2637,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-19b6094e
+    value: updnet-ratio-100mice-20260703-190745-54272cc8
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-042
+- name: updnet-ratio-100mice-20260703-190745-042
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2640,10 +2679,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=1e-3
   - model.training.lr=5e-3
@@ -2659,29 +2700,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-49031e9c
+    value: updnet-ratio-100mice-20260703-190745-db1a2af8
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-043
+- name: updnet-ratio-100mice-20260703-190745-043
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2702,10 +2742,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=1e-3
   - model.training.lr=5e-3
@@ -2721,29 +2763,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-9e3e832b
+    value: updnet-ratio-100mice-20260703-190745-dd277415
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-044
+- name: updnet-ratio-100mice-20260703-190745-044
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2764,10 +2805,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=3e-3
   - model.training.lr=1e-3
@@ -2783,29 +2826,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-d8f3f6dc
+    value: updnet-ratio-100mice-20260703-190745-238e20a0
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-045
+- name: updnet-ratio-100mice-20260703-190745-045
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2826,10 +2868,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=3e-3
   - model.training.lr=1e-3
@@ -2845,29 +2889,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-fb55a036
+    value: updnet-ratio-100mice-20260703-190745-3df0abad
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-046
+- name: updnet-ratio-100mice-20260703-190745-046
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2888,10 +2931,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=3e-3
   - model.training.lr=5e-3
@@ -2907,29 +2952,28 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-3f7c66e7
+    value: updnet-ratio-100mice-20260703-190745-48ff99c4
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:
     priority: low
     preemptible: true
-- name: updnet-ratio-100mice-20260703-142019-047
+- name: updnet-ratio-100mice-20260703-190745-047
   image:
     beaker: han-hou/disrnn-wrapper-pck-integration-20260630
   command:
@@ -2950,10 +2994,12 @@ tasks:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  - model.training.n_steps=150000
+  - model.training.n_steps=60000
   - model.training.n_warmup_steps=7500
   - model.training.checkpoint_every_n_steps=10000
   - model.training.checkpoint_run_heldout_eval=false
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - model.penalties.update_net_latent_penalty_multiplier=10
   - model.penalties.beta=3e-3
   - model.training.lr=5e-3
@@ -2969,23 +3015,22 @@ tasks:
   - name: WANDB_API_KEY
     secret: han-wandb-api-key
   - name: WRAPPER_REF
-    value: eaca1a0cb6d8c8fe60c8ee5e4667f02774e530bf
+    value: 87d93f8c989e2059b67c1e87c137f799103ada77
   - name: DISPATCHER_REF
     value: feat/beta-scan
   - name: DISRNN_RESUMABLE_OUTPUT_DIR
     value: /results/run
   - name: WANDB_RUN_ID
-    value: updnet-ratio-100mice-20260703-142019-598d6848
+    value: updnet-ratio-100mice-20260703-190745-afe0403e
   - name: WANDB_RESUME
     value: allow
   - name: WANDB_RUN_GROUP
-    value: updnet-ratio-100mice@20260703-142019
+    value: updnet-ratio-100mice@20260703-190745
   - *id001
   - *id002
   - *id003
   - *id004
   - *id005
-  - *id006
   result:
     path: /results
   context:

--- a/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/sweep.yaml
+++ b/studies/beta-scan/variants/updnet-ratio-100mice/launch_record/sweep.yaml
@@ -9,10 +9,19 @@
 # GAP this closes: Po-Chen only ever scanned this multiplier at <=10 mice; never at 100.
 #
 # disRNN-trainer NOTES (differ from the gru_scaling sweeps — do NOT copy those verbatim):
-#   * NO early_stopping / length_bucketing keys — those are gru_trainer-only; the disRNN
-#     trainer has no such fields and Hydra would error on them.
+#   * NO early_stopping key — that is gru_trainer-only; the disRNN trainer has no such
+#     field and Hydra would error on it.
+#   * length_bucketing IS now supported by the disRNN trainer (wired to the shared
+#     _sample_batch, mirroring gru_trainer.py); enabled below to trim per-batch unroll
+#     from the global T_max to each batch's own session length, cutting padding compute.
 #   * n_warmup_steps here is the disRNN *penalty* warmup (~5% of n_steps, Po-Chen convention).
 #   * session_* are the scalar session-conditioning knobs carried from data-scaling-law.
+#
+# STAGED HORIZON (this round): n_steps is SHORT (60000, ~40% of the original 150000) to get
+# all 4 multipliers to a comparable, interpretable point fast. checkpoint_every_n_steps is
+# kept small so the full resumable state is uploaded per run; a later continuation experiment
+# can extend promising cells via model.training.restore_from_run_id (see wrapper beaker/README
+# §3b) instead of restarting from scratch.
 entity: AIND-disRNN
 project: disrnn_updnet_bottleneck_ratio_100mice
 name: mice-beta-scan-updnet-ratio-100mice     # informational; launcher sets the real group
@@ -39,11 +48,14 @@ command:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  # --- training budget ---
-  - model.training.n_steps=150000
-  - model.training.n_warmup_steps=7500          # disRNN penalty warmup (~5% of n_steps)
-  - model.training.checkpoint_every_n_steps=10000  # ~15 sparsity/likelihood logs per run
+  # --- training budget (SHORT horizon this round; extend later if promising) ---
+  - model.training.n_steps=60000
+  - model.training.n_warmup_steps=7500          # disRNN penalty warmup (unchanged: full penalty ramp before main training)
+  - model.training.checkpoint_every_n_steps=10000  # ~6 sparsity/likelihood logs + resumable state per run
   - model.training.checkpoint_run_heldout_eval=false
+  # --- length-bucketed batching: trim per-batch unroll to the batch's session length ---
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - ${args_no_hyphens}
 parameters:
   model.penalties.update_net_latent_penalty_multiplier:

--- a/studies/beta-scan/variants/updnet-ratio-100mice/notes.md
+++ b/studies/beta-scan/variants/updnet-ratio-100mice/notes.md
@@ -27,10 +27,24 @@ interaction latent bottlenecks with σ < 0.1) — lower = sparser interaction. A
 (one 90GiB / 12-CPU bundle), NOT `octo-hub-onprem-h200`. Keeping it off H200 also avoids
 contending with the running `ignore-trials-scaling/nxd-3way` grid there.
 
-**disRNN-trainer caveat.** `sweep.yaml` deliberately OMITS `early_stopping` and
-`length_bucketing` — those exist only in `gru_trainer`, and the disRNN trainer would error on
-them. `n_warmup_steps=7500` here is the disRNN *penalty* warmup (~5% of `n_steps`), not GRU
-early-stopping.
+**Staged horizon (this round).** `n_steps=60000` (not 150k) so all four multipliers reach a
+comparable, interpretable point fast. `checkpoint_every_n_steps=10000` keeps the full
+resumable state uploading per run, so promising cells can be **extended later** to a longer
+horizon via `model.training.restore_from_run_id=<source run id>` — it downloads that run's
+`disrnn-output-<id>` W&B artifact and continues from its checkpoint (skips warmup) instead of
+restarting. Set a larger `n_steps` than the source (loop is `while steps_completed < n_steps`).
+Because extending only some cells makes the grid horizon-heterogeneous, read any cross-cell
+comparison at a common step (loss-pace logging supports this).
+
+**Length bucketing ON.** `model.training.length_bucketing=true` + `length_bucket_grid=128`
+trims each `random`-mode batch's unroll from the global `T_max`≈1488 to the batch's own
+session length — **measured ~1.86× throughput** (2015→1083 ms/step, matched config). Requires
+`batch_mode=random` (satisfied: batch is `random`/2048, inherited from `mice_snapshot_scaling`).
+
+**disRNN-trainer caveat.** `sweep.yaml` deliberately OMITS `early_stopping` — that exists only
+in `gru_trainer`, and the disRNN trainer would error on it. `n_warmup_steps=7500` here is the
+disRNN *penalty* warmup, not GRU early-stopping. (`length_bucketing` is now supported by the
+disRNN trainer as of wrapper `87d93f8c` — the config declares the keys.)
 
 **Launch (render-first — inspect the rendered spec before any real submit):**
 ```bash

--- a/studies/beta-scan/variants/updnet-ratio-100mice/sweep.yaml
+++ b/studies/beta-scan/variants/updnet-ratio-100mice/sweep.yaml
@@ -9,10 +9,19 @@
 # GAP this closes: Po-Chen only ever scanned this multiplier at <=10 mice; never at 100.
 #
 # disRNN-trainer NOTES (differ from the gru_scaling sweeps — do NOT copy those verbatim):
-#   * NO early_stopping / length_bucketing keys — those are gru_trainer-only; the disRNN
-#     trainer has no such fields and Hydra would error on them.
+#   * NO early_stopping key — that is gru_trainer-only; the disRNN trainer has no such
+#     field and Hydra would error on it.
+#   * length_bucketing IS now supported by the disRNN trainer (wired to the shared
+#     _sample_batch, mirroring gru_trainer.py); enabled below to trim per-batch unroll
+#     from the global T_max to each batch's own session length, cutting padding compute.
 #   * n_warmup_steps here is the disRNN *penalty* warmup (~5% of n_steps, Po-Chen convention).
 #   * session_* are the scalar session-conditioning knobs carried from data-scaling-law.
+#
+# STAGED HORIZON (this round): n_steps is SHORT (60000, ~40% of the original 150000) to get
+# all 4 multipliers to a comparable, interpretable point fast. checkpoint_every_n_steps is
+# kept small so the full resumable state is uploaded per run; a later continuation experiment
+# can extend promising cells via model.training.restore_from_run_id (see wrapper beaker/README
+# §3b) instead of restarting from scratch.
 entity: AIND-disRNN
 project: disrnn_updnet_bottleneck_ratio_100mice
 name: mice-beta-scan-updnet-ratio-100mice     # informational; launcher sets the real group
@@ -39,11 +48,14 @@ command:
   - model.architecture.session_encoding_type=scalar
   - model.architecture.session_n_pretrain_steps=30000
   - model.architecture.session_n_warmup_steps=20000
-  # --- training budget ---
-  - model.training.n_steps=150000
-  - model.training.n_warmup_steps=7500          # disRNN penalty warmup (~5% of n_steps)
-  - model.training.checkpoint_every_n_steps=10000  # ~15 sparsity/likelihood logs per run
+  # --- training budget (SHORT horizon this round; extend later if promising) ---
+  - model.training.n_steps=60000
+  - model.training.n_warmup_steps=7500          # disRNN penalty warmup (unchanged: full penalty ramp before main training)
+  - model.training.checkpoint_every_n_steps=10000  # ~6 sparsity/likelihood logs + resumable state per run
   - model.training.checkpoint_run_heldout_eval=false
+  # --- length-bucketed batching: trim per-batch unroll to the batch's session length ---
+  - model.training.length_bucketing=true
+  - model.training.length_bucket_grid=128
   - ${args_no_hyphens}
 parameters:
   model.penalties.update_net_latent_penalty_multiplier:


### PR DESCRIPTION
## Summary
Short-horizon, length-bucketed relaunch of the disRNN update-net-ratio β-scan at 100 mice, plus the config + tooling to support a staged-horizon workflow.

- **`config/model/disrnn.yaml`** — declare `length_bucketing` / `length_bucket_grid` / `restore_from_run_id` in the disRNN training schema (Hydra struct-mode requires the keys to exist before a sweep can override them; the GRU config already had the first two). Caught by the length-bucketing smoke.
- **`studies/beta-scan/variants/updnet-ratio-100mice`** — `n_steps` 150000 → **60000** (staged horizon: all four multipliers reach a comparable, interpretable point fast; extend promising cells later via `restore_from_run_id`); enable `length_bucketing=true` (**~1.86× throughput**, measured); keep batch `random`/2048 (inherited); bump `WRAPPER_REF` → `87d93f8c`.
- **`studies/beta-scan/analysis/monitor_beta_scan.py`** — live monitor for loss + bottleneck-sparsity trajectories (manual early-stop aid).
- **smoke variant** — same config at `n_steps=4000` for trim + resume verification.
- **README / notes** — document the staged-horizon workflow, length bucketing (with numbers), and RUNNING status.

## Grid launched
`01KWNH6J6YV382HH35GSDWNJAE` — 48 tasks, group `updnet-ratio-100mice@20260703-200122`, cluster `ai1/octo.ai-aws-g6e`. Supersedes the stopped 150k grid `01KWMXQDX0`. Est ~6–7.5 days at ~5–6 concurrent (vs ~10–27 days for the old 150k grid).

## Isolation note
Base is `feat/ignore-trials-scaling` (as in the prior merged #34). Diff vs this base is **0 ignore-trials files** — this PR contains only the beta-scan study + the disRNN config key additions. The concurrently-running `ignore-trials-scaling/nxd-3way` launch-record working-tree changes were deliberately left uncommitted and untouched throughout (owned by a concurrent session).

## Depends on
Wrapper PR (length bucketing + extend-later restore) — the `WRAPPER_REF` `87d93f8c` this study pins. Beaker pulls by SHA at runtime, so the running grid already uses it.
