### PR TITLE
docs(skills): document extend/restore + held-out re-scoring in launch skills

### DIFF
--- a/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
+++ b/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aind-behavior-foundation-model-skills",
   "description": "Agent Skills for the AIND behavior foundation model stack: codebase orientation for the disRNN dispatcher/wrapper repos, launching jobs on Beaker (AI Hub) and Allen on-prem SLURM HPC, study/variant organization, and post-hoc analysis reporting conventions.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Han Hou",
     "email": "houhan@gmail.com"

--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: beaker-launch
-description: Launch, size, and monitor training jobs on Beaker (AI Hub) for the disRNN stack — cluster allowlist, preferred cluster order, priority/preemption rules, GPU-bundle sizing, the resumable launcher, and validation. Use whenever submitting, debugging, or scheduling Beaker experiments or W&B sweeps on AI Hub clusters.
+description: Launch, size, and monitor training jobs on Beaker (AI Hub) for the disRNN stack — cluster allowlist, preferred cluster order, priority/preemption rules, GPU-bundle sizing, the resumable launcher, extend/restore (`restore_from_run_id`) and held-out re-scoring, and validation. Use whenever submitting, debugging, or scheduling Beaker experiments or W&B sweeps on AI Hub clusters.
 ---
 
 # Launching on Beaker (AI Hub)
@@ -109,6 +109,39 @@ Native alternative (real `wandb agent` sweep, not preemption-resilient):
 Per-task cluster/resource splits aren't supported by the launcher — render with
 `--no-submit`, edit `constraints.cluster`/`resources` per task, then
 `beaker experiment create -w "$WS" <spec>.yaml`.
+
+## Resuming, extending & re-scoring runs
+
+Three distinct mechanisms — don't conflate them (full lifecycle detail: wrapper
+`../aind-disrnn-wrapper/code/TRAINING.md` §1.5 "Run lifecycle & key switches"):
+
+1. **Preemption resume — automatic, WITHIN one experiment.** Covered under
+   "Priority & preemption" above: a preempted `preemptible: true` task restarts as
+   the *same* task with the *same* `/results` dataset, re-finds its latest
+   `checkpoints/step_<N>/train_state.pkl`, and continues (skipping warmup). Needs
+   `checkpoint_every_n_steps > 0` + `auto_resume` (default). No flags, no new
+   experiment.
+2. **Extend a finished run to a longer horizon — ACROSS experiments.** Launch a
+   *new* experiment with `model.training.restore_from_run_id=<source W&B run name>`
+   (or per-cell env `DISRNN_RESTORE_FROM_RUN_ID` — env wins, so a sweep can pass a
+   per-cell id) and a **larger** `n_steps`. Before training, the entrypoint downloads
+   the source run's `<mtype>-output-<run_id>:latest` artifact (`mtype` ∈
+   {`disrnn`,`gru`}) into `outputs/`, so the trainer resumes from its checkpoint and
+   skips warmup. Trainer-agnostic. **Prereq: the source run must have FINISHED** — its
+   `training-output` artifact is uploaded once at end of training (not per checkpoint),
+   so in-progress runs cannot be extended. Fails **loudly** if the artifact is missing —
+   never silently restarts from scratch.
+3. **Re-score a finished run's held-out stage only — no re-training.**
+   `python resume_heldout_beaker.py --run-id <wandb_run_id>` (wrapper repo root, inside
+   a Beaker container that reaches GCS + W&B). Runs the held-out fine-tune ONLY off the
+   downloaded checkpoint tree, reads every knob (seed, `checkpoint_policy`, held-out set,
+   finetune `n_steps`/`lr`) from the SOURCE run's own config, and re-injects `heldout/*`
+   back into the ORIGINAL W&B run. Use it to backfill metrics added *after* a run trained
+   (e.g. the 3-way ignore-class precision/recall/F1/PR-AUC). This is the
+   **exact-reproduction** path: unlike (2)'s restore — which resumes the training
+   entrypoint and redraws a fresh held-out set off the restored checkpoints — this
+   reproduces the source run's original held-out numbers. (Beaker port of the HPC
+   `resume_heldout.py`.)
 
 ## Validate, then fan out
 

--- a/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hpc-launch
-description: Launch and monitor disRNN training on the Allen on-premise SLURM HPC (AI1) — launch_hpc.py W&B sweep arrays, manual sbatch/Hydra multirun, dry-run/smoke-test patterns, GPU tiers, squeue/sacct monitoring. Use whenever running jobs on the Allen cluster via srun/sbatch rather than Beaker.
+description: Launch and monitor disRNN training on the Allen on-premise SLURM HPC (AI1) — launch_hpc.py W&B sweep arrays, manual sbatch/Hydra multirun, dry-run/smoke-test patterns, GPU tiers, extend/restore and held-out re-scoring, squeue/sacct monitoring. Use whenever running jobs on the Allen cluster via srun/sbatch rather than Beaker.
 ---
 
 # Launching on Allen on-prem HPC (SLURM)
@@ -85,6 +85,27 @@ sbatch --export=ALL,WRAPPER_ROOT=/path/to/aind-disrnn-wrapper \
 sbatch --export=ALL,WRAPPER_ROOT=/path/to/aind-disrnn-wrapper \
   code/hpc/slurm/hydra_multirun_gpu.slurm   # or _cpu.slurm
 ```
+
+## Resuming, extending & re-scoring runs
+
+HPC `aind` jobs are **not preempted** (queue / fair-share scheduling, not Beaker's
+preemptible-priority tiers), so the "resume after preemption" scenario does not arise
+here — that mechanism is Beaker-only. The other two work the same as on Beaker (full
+detail: wrapper `../aind-disrnn-wrapper/code/TRAINING.md` §1.5):
+
+- **Extend a finished run to a longer horizon.** Set
+  `model.training.restore_from_run_id=<source W&B run name>` (or env
+  `DISRNN_RESTORE_FROM_RUN_ID`) and a **larger** `n_steps`. `run_hpc.py` downloads the
+  source run's `<mtype>-output-<run_id>` artifact (`mtype` ∈ {`disrnn`,`gru`}) into
+  `outputs/` before training, so it resumes from the checkpoint and skips warmup.
+  Trainer-agnostic. Prereq: the source run must have FINISHED (its `training-output`
+  artifact is COMMITTED).
+- **Re-score a finished run's held-out stage only — no re-training.** Runs the held-out
+  fine-tune off the existing checkpoint and re-injects `heldout/*` into the original
+  W&B run — used to backfill metrics added *after* a run trained. The committed
+  reference implementation is the wrapper's Beaker port `resume_heldout_beaker.py`
+  (`--run-id <wandb_run_id>`, inside a container reaching GCS + W&B); an HPC-side ad-hoc
+  variant (`resume_heldout.py`) has been used but is not yet committed to the repo.
 
 ## Monitoring
 


### PR DESCRIPTION
## What

Documents the three run resume/extend/re-score mechanisms in the two launch skills, closing a gap where only automatic preemption-resume was covered.

**`beaker-launch/SKILL.md`** — new "Resuming, extending & re-scoring runs" section:
1. Preemption resume (automatic, within one experiment) — cross-references existing Priority & preemption section.
2. **Extend a finished run** to a longer horizon via `model.training.restore_from_run_id` / env `DISRNN_RESTORE_FROM_RUN_ID` + larger `n_steps` (the knob was previously unnamed anywhere in the skills).
3. **Held-out-only re-score** via `resume_heldout_beaker.py` — the exact-reproduction backfill path, distinguished from (2)'s restore.

**`hpc-launch/SKILL.md`** — same section, adapted: notes HPC `aind` jobs are not preempted (so mechanism 1 is Beaker-only), documents extend/restore via `run_hpc.py` and the held-out re-score.

Both descriptions updated so search surfaces these; plugin version 0.2.0 -> 0.3.0.

## Why

`restore_from_run_id` (extend) and the held-out re-score script were only findable by grepping code / the wrapper `TRAINING.md` §1.5 (merged in wrapper PR #47). Neither launch skill named them. Full lifecycle detail still lives in §1.5; these sections give the operational entry points and point there.

## Notes
- Docs-only; no code or behavior change. Does not touch running jobs.
- The imported (read-only) skill pack mirrors this repo path, so it refreshes on the next plugin re-import.
