### PR TITLE
docs(beaker-launch): disambiguate training.auto_resume from Beaker autoResume field

### DIFF
--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
@@ -119,7 +119,8 @@ Three distinct mechanisms — don't conflate them (full lifecycle detail: wrappe
    "Priority & preemption" above: a preempted `preemptible: true` task restarts as
    the *same* task with the *same* `/results` dataset, re-finds its latest
    `checkpoints/step_<N>/train_state.pkl`, and continues (skipping warmup). Needs
-   `checkpoint_every_n_steps > 0` + `auto_resume` (default). No flags, no new
+   `checkpoint_every_n_steps > 0` + the trainer gate `training.auto_resume` (default; distinct
+   from Beaker's own `autoResume` spec field above). No flags, no new
    experiment.
 2. **Extend a finished run to a longer horizon — ACROSS experiments.** Launch a
    *new* experiment with `model.training.restore_from_run_id=<source W&B run name>`


### PR DESCRIPTION
Follow-up to #45. The new resume section wrote a bare `auto_resume` next to the existing `autoResume` (Beaker spec field) text, which reads as an inconsistent casing of the same field. They are two different things: `training.auto_resume` is the trainer-config gate (per wrapper TRAINING.md §1.5 / code/beaker/README.md), while `autoResume` is Beaker's server-side spec field. Qualified the trainer gate as `training.auto_resume` and noted the distinction. Docs-only.