### PR TITLE
docs(skills): update resume-script paths (moved into code/, HPC script now committed)

### DIFF
--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
@@ -133,7 +133,7 @@ Three distinct mechanisms — don't conflate them (full lifecycle detail: wrappe
    so in-progress runs cannot be extended. Fails **loudly** if the artifact is missing —
    never silently restarts from scratch.
 3. **Re-score a finished run's held-out stage only — no re-training.**
-   `python resume_heldout_beaker.py --run-id <wandb_run_id>` (wrapper repo root, inside
+   `python code/resume_heldout_beaker.py --run-id <wandb_run_id>` (from the wrapper repo, inside
    a Beaker container that reaches GCS + W&B). Runs the held-out fine-tune ONLY off the
    downloaded checkpoint tree, reads every knob (seed, `checkpoint_policy`, held-out set,
    finetune `n_steps`/`lr`) from the SOURCE run's own config, and re-injects `heldout/*`
@@ -142,7 +142,7 @@ Three distinct mechanisms — don't conflate them (full lifecycle detail: wrappe
    **exact-reproduction** path: unlike (2)'s restore — which resumes the training
    entrypoint and redraws a fresh held-out set off the restored checkpoints — this
    reproduces the source run's original held-out numbers. (Beaker port of the HPC
-   `resume_heldout.py`.)
+   `code/resume_heldout.py`; both now live under `code/`.)
 
 ## Validate, then fan out
 

--- a/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
@@ -103,9 +103,10 @@ detail: wrapper `../aind-disrnn-wrapper/code/TRAINING.md` §1.5):
 - **Re-score a finished run's held-out stage only — no re-training.** Runs the held-out
   fine-tune off the existing checkpoint and re-injects `heldout/*` into the original
   W&B run — used to backfill metrics added *after* a run trained. The committed
-  reference implementation is the wrapper's Beaker port `resume_heldout_beaker.py`
-  (`--run-id <wandb_run_id>`, inside a container reaching GCS + W&B); an HPC-side ad-hoc
-  variant (`resume_heldout.py`) has been used but is not yet committed to the repo.
+  reference implementations both live under the wrapper's `code/`: the Beaker port
+  `code/resume_heldout_beaker.py` (`--run-id <wandb_run_id>`, inside a container reaching
+  GCS + W&B) and the HPC original `code/resume_heldout.py` (`--model-dir <dir> --wandb-run-id
+  <id>`, run on a compute node that can read the checkpoint tree + reach W&B).
 
 ## Monitoring
 


### PR DESCRIPTION
Companion to wrapper PR #50, which moves `resume_heldout_beaker.py` into `code/` and commits the HPC `resume_heldout.py` there too.

- `beaker-launch`: `resume_heldout_beaker.py` -> `code/resume_heldout_beaker.py`; note both scripts now live under `code/`.
- `hpc-launch`: drop the “not yet committed” caveat; both re-score entry points now committed under `code/`, with the HPC script's actual args (`--model-dir`/`--wandb-run-id`).

Docs-only. Merge after #50.