### PR TITLE
docs: p5en preemptible exception, three job-protection tiers, beaker-py setup + all-cluster gpu check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,8 +135,9 @@ and is not allowed.
   launcher/control-plane environment for `wandb`, `beaker`, and YAML tooling.
 - **Submit ONLY to `hub` clusters** (the team's pools: `octo-hub-*`, `octo.hub-*`, `aihub-*`).
   **NEVER** to non-hub clusters (`aipbd-*`, `siti-*`, `dev-*`, other `octo.ai-*`) even if idle
-  — they're not ours. Sole verified exception: `ai1/octo.ai-aws-g6e` accepts our **low-priority
-  preemptible** jobs (AWS, reaches S3, L40S bundle).
+  — they're not ours. Verified exceptions (non-hub `octo.ai-aws-*`, but admit our
+  **low-priority preemptible** jobs — AWS, reach S3): `ai1/octo.ai-aws-g6e` (L40S bundle)
+  and `ai1/octo.ai-aws-p5en` (H200 141 GB bundle).
 - **Check schedulable capacity BEFORE launching any large job (> 4 GPUs / > 4 concurrent
   tasks): `python code/check_gpu_availability.py`** (Beaker + HPC). Route to whichever backend
   has room. "Free" is not "schedulable": Beaker reports GPUs on **cordoned** nodes as free
@@ -145,14 +146,20 @@ and is not allowed.
   below has open slots.
 - Cluster choice: pick by **live schedulable capacity first**. `ai1/octo.ai-aws-g6e` (L40S,
   low/preemptible-only exception) and `ai1/octo-hub-aws-l40s` (L40S) for general jobs;
-  `ai1/octo-hub-onprem-h200` **only when a task needs the 141 GB** (wide `hidden_size=256`
+  `ai1/octo-hub-onprem-h200` / `ai1/octo.ai-aws-p5en` (the H200 preemptible exception)
+  **only when a task needs the 141 GB** (wide `hidden_size=256`
   OOMs a 48 GB L40S). **H200 is not inherently faster than L40S/g6e** — do not prefer it on
   speed grounds. When all Beaker clusters are saturated/cordoned, HPC SLURM (`aind` partition)
   is the GPU overflow — check it with `--hpc` and launch there (§13 load-balancing).
 - Heavy work never on the login node (see §5).
-- Scheduling detail — priority/bursting, GPU-bundle sizing (`--memory 90GiB --cpu 12` = 1 L40s
-  GPU), the g6e exception, cross-cloud S3 caveat, quota debugging, one-unit validation: the
-  **`beaker-launch` skill** (`aind-behavior-foundation-model-skills/skills/beaker-launch/`,
+- **Three job-protection tiers in our workspace:** (1) **4 allocated** slots — protected
+  non-preemptible (`{normal/high, preemptible: false}`), never evicted; (2) **8 unallocated**
+  slots — normal-priority preemptible, hard cap; (3) **~unlimited low-preemptible**
+  (`{low, preemptible: true}`) — bursts past the 8-cap onto spare GPUs, evicted first,
+  auto-resumes. Default fan-outs → tier 3 (`priority: low`); must-finish runs → tier 1.
+- Scheduling detail — the tier table/measurements, GPU-bundle sizing (`--memory 90GiB --cpu 12`
+  = 1 L40s GPU), the g6e/p5en exceptions, cross-cloud S3 caveat, quota debugging, one-unit
+  validation: the **`beaker-launch` skill** (`aind-behavior-foundation-model-skills/skills/beaker-launch/`,
   read before any non-trivial launch).
 
 ## 11. Verify Mechanisms With Data Before Asserting

--- a/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
+++ b/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aind-behavior-foundation-model-skills",
   "description": "Agent Skills for the AIND behavior foundation model stack: codebase orientation for the disRNN dispatcher/wrapper repos, launching jobs on Beaker (AI Hub) and Allen on-prem SLURM HPC, study/variant organization, and post-hoc analysis reporting conventions.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Han Hou",
     "email": "houhan@gmail.com"

--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
@@ -15,8 +15,9 @@ resumable mechanics).
 1. **Submit ONLY to `hub` clusters** (`octo-hub-*`, `octo.hub-*`, `aihub-*`).
    **NEVER** to non-hub clusters (`aipbd-*`, `siti-*`, `dev-*`, other `octo.ai-*`)
    even if idle — they belong to other science units.
-   Sole verified exception: `ai1/octo.ai-aws-g6e` accepts our **low-priority
-   preemptible** jobs only (see `references/scheduling-lessons.md`).
+   Verified exceptions: `ai1/octo.ai-aws-g6e` (L40S) and `ai1/octo.ai-aws-p5en`
+   (H200 141 GB) accept our **low-priority preemptible** jobs only
+   (see `references/scheduling-lessons.md`).
 2. **Never run the launch's compute on the login node** — the launcher itself is fine
    (it only submits), the training is not.
 3. Use the `disrnn-cpu` conda env for `wandb`/`beaker`/YAML tooling:
@@ -46,12 +47,15 @@ only option (preemptible jobs burst as capacity frees / nodes uncordon).
 
 Pick by **live schedulable capacity first**, then by these properties:
 
-- `ai1/octo.ai-aws-g6e` — L40S 48GB, many slots; **low/preemptible only** (the
+- `ai1/octo.ai-aws-g6e` — L40S 48GB, many slots; **low/preemptible only** (a
   verified non-hub exception).
 - `ai1/octo-hub-aws-l40s` — L40S 48GB, same class.
 - `ai1/octo-hub-onprem-h200` — H200 141GB. **Use only when a task needs the memory**
   (wide `hidden_size=256` OOMs a 48GB L40S). **H200 is NOT inherently faster than
   L40S/g6e** for our workloads — do not prefer it on speed grounds.
+- `ai1/octo.ai-aws-p5en` — H200 141GB (8/node); **low/preemptible only** (the other
+  verified non-hub exception). The preemptible route to H200 memory when the on-prem
+  H200 pool is full.
 
 **GCP clusters cannot reach AWS S3** — never route DB/S3-backed jobs there.
 

--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/references/sandbox-launch.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/references/sandbox-launch.md
@@ -12,6 +12,25 @@ directly (no `wandb-core` subprocess), and `get_beaker_client()` builds
 - Credentials already in the sandbox env: `BEAKER_TOKEN`, `WANDB_API_KEY`.
 - Network: `beaker.org` and `api.wandb.ai` each need a one-time
   `request_network_access` grant.
+- **`beaker-py` (the `beaker` Python SDK)** — required by `beaker_client.py` and
+  `code/check_gpu_availability.py`. The launch stack targets the **1.x** API
+  (`from beaker import Beaker, Config`); **`beaker-py` 2.x is a breaking rewrite
+  that drops that import — do NOT install 2.x.** The sandbox Python is
+  externally-managed (PEP 668) and its stdlib `venv` lacks `ensurepip`, so build
+  the venv with `uv`:
+
+  ```bash
+  uv venv ~/.venvs/beaker
+  uv pip install --python ~/.venvs/beaker/bin/python "beaker-py<2"
+  # run the checker / launchers with that interpreter:
+  BEAKER_TOKEN=$(grep -i user_token ~/.beaker/config.yml | sed 's/.*:[[:space:]]*//') \
+    ~/.venvs/beaker/bin/python code/check_gpu_availability.py --beaker
+  ```
+
+  1.x emits harmless `RuntimeWarning: Found unknown field ...` for newer Beaker
+  API fields it doesn't model; results are unaffected. `check_gpu_availability.py`
+  reads the token from `$BEAKER_TOKEN` (not `~/.beaker/config.yml`), so export it
+  as shown.
 
 **PYTHONPATH quirk (sandbox only):** `PYTHONSAFEPATH=1` drops the script dir from
 `sys.path`, so the launchers' sibling imports (`beaker_client`, ...) fail with

--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/references/scheduling-lessons.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/references/scheduling-lessons.md
@@ -16,7 +16,37 @@ assume guaranteed slots there. Other `octo.ai-*` / `aipbd-*` / `siti-*` clusters
 remain off-limits unless similarly verified (probe
 `beaker cluster get --format json` for `allowPreemptibleRestrictionExceptions`).
 
+## The verified p5en exception (2026-07-12)
+
+`ai1/octo.ai-aws-p5en` is the second non-hub `octo.ai-aws-*` cluster verified the
+same way: `beaker cluster get` reports `allowPreemptibleRestrictionExceptions:
+True` (identical to g6e), so **low-priority preemptible** jobs are admitted past
+its user-whitelist. It is **AWS** (reaches S3) with **NVIDIA H200 141 GB** GPUs,
+**3 nodes × 8 = 24 slots**. This is the **preemptible route to H200 memory** — use
+it for wide `hidden_size=256` (which OOMs a 48 GB L40S) when the on-prem H200 pool
+is full, as burst capacity only (never assume guaranteed slots). Bundle sizing is
+the H200 shape, not the L40S `--memory 90GiB --cpu 12` — size to one H200 bundle
+and confirm `BEAKER_ASSIGNED_GPU_COUNT=1`. As with g6e, H200 is chosen here for
+**memory, not speed**.
+
 ## Priority tiers (verified on onprem-H200 + aws-L40s, 2026-06-22)
+
+**Our workspace (`ai1/aind-dynamic-foraging-foundation-model`) has three tiers of
+job protection** — pick the tier by how much the job must resist eviction:
+
+| Tier | How to submit | Budget | Eviction |
+|---|---|---|---|
+| **1. Allocated / protected** | `{priority: normal or high, preemptible: false}` | **4 allocated slots** | never evicted (guaranteed) |
+| **2. Unallocated / preemptible-normal** | `{priority: normal/high, preemptible: true}` | **8 unallocated slots** (hard cap) | evicted under contention; auto-resumes |
+| **3. Low preemptible (burst)** | `{priority: low, preemptible: true}` | **~unlimited** (best-effort spare GPUs, *ignores* the 8-slot cap) | evicted first; auto-resumes |
+
+Rules of thumb: default fan-outs → **tier 3** (`priority: low`) for max throughput;
+a few must-finish runs → **tier 1** (4 protected slots); **tier 2** only when a job
+must resist eviction but you've exhausted the 4 allocated slots. `maxWorkloadPriority`
+for this workspace is `high` (verified 2026-07-12), so `high` is available above
+`normal`. The **4 / 8** budget figures are from the 2026-06-22 measurement (the beaker
+CLI does not expose the workspace's slot budget directly — re-derive by watching where
+`normal`-preemptible starts pending vs. bursting).
 
 - **Low-priority preemptible jobs burst onto spare idle GPUs *beyond* the
   workspace's unallocated-slot budget** (measured ~14 concurrent on H200), whereas

--- a/aind-behavior-foundation-model-skills/skills/codebase-map/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/codebase-map/SKILL.md
@@ -67,8 +67,8 @@ description: Orient in the aind-disrnn-dispatcher codebase — the two-repo arch
 ## Non-negotiable rules (from AGENTS.md)
 
 - **Never run heavy work on the login node** — always `srun`/`sbatch` (HPC) or Beaker.
-- Beaker: **submit only to `hub` clusters** (+ the one verified `octo.ai-aws-g6e`
-  low/preemptible exception) — see the beaker-launch skill.
+- Beaker: **submit only to `hub` clusters** (+ the verified `octo.ai-aws-g6e` and
+  `octo.ai-aws-p5en` low/preemptible exceptions) — see the beaker-launch skill.
 - **Check schedulable capacity before any large launch** (> 4 GPUs / > 4 concurrent
   tasks): `python code/check_gpu_availability.py` — raw `beaker cluster list`/`sinfo`
   counts include cordoned/drained nodes and lie.

--- a/code/beaker/README.md
+++ b/code/beaker/README.md
@@ -78,7 +78,9 @@ Hub clusters — use these (resources measured 2026-06-21; re-check with
 
 Preferred order for known-good low/preemptible S3-backed jobs: `ai1/octo.ai-aws-g6e`
 first (verified exception; L40S has been faster than H200 for our current workloads and
-has many slots), then `ai1/octo-hub-onprem-h200`, then `ai1/octo-hub-aws-l40s`.
+has many slots), then `ai1/octo-hub-onprem-h200`, then `ai1/octo-hub-aws-l40s`. For jobs
+that need H200 memory (wide H256) preemptibly, `ai1/octo.ai-aws-p5en` is the second
+verified exception (H200 141 GB) when the on-prem H200 pool is full.
 
 | Cluster | GPU (mem) | Host RAM/node | Reaches DB? | Notes |
 |---|---|---|---|---|
@@ -86,6 +88,7 @@ has many slots), then `ai1/octo-hub-onprem-h200`, then `ai1/octo-hub-aws-l40s`.
 | `ai1/octo-hub-aws-l40s` | L40s (48 GB) | ~373 GiB (1 node, 4 slots) | ✅ AWS | default; fine for H128. 48 GB GPU OOMs a *wide* (hidden_size=256) full-cohort eval unless chunked |
 | `ai1/octo-hub-aws-h200` | H200 (141 GB) | large | ✅ AWS | large training; often full (32/32) |
 | `ai1/octo-hub-onprem-h200` | H200 (141 GB) | ~3.25 TiB | ✅ on-prem | large training; usually has free slots — best for wide H256 |
+| `ai1/octo.ai-aws-p5en` | H200 (141 GB) | large (8/node, 3 nodes = 24 slots) | ✅ AWS | **verified exception for low/preemptible jobs only**; the preemptible route to H200 memory when on-prem H200 is full |
 | `ai1/octo-hub-gcp-h100` | H100 (80 GB) | ~1.83 TiB | ❌ **cannot reach AWS S3 DB** | lots of free CPU/RAM, but DB reads fail (DNS / SSL-cert errors) — only for compute that doesn't touch the DB |
 | `ai1/octo.hub-gcp-h200` | H200 (141 GB) | large | ❌ GCP (S3 unreliable) | |
 | `ai1/octo-hub-aws-l40s-dev` | L40s (48 GB) | — | ✅ AWS | dev |
@@ -97,9 +100,10 @@ us-west-2); **GCP clusters cannot reliably read it** (intermittent
 `Could not resolve hostname` / `SSL CA cert` `IOException`s mid-fetch). The DB
 fetch itself is fast on AWS (~5 s for all ~12.5M trials; scales with CPU count).
 
-Do **not** use (other units' allocations, not hub): `ai1/aipbd-aws-h200`,
-`ai1/octo.ai-aws-p5en`, or other non-hub clusters. The sole current exception is
-`ai1/octo.ai-aws-g6e` for verified **low-priority preemptible** jobs.
+Do **not** use (other units' allocations, not hub): `ai1/aipbd-aws-h200` or other
+non-hub clusters. The current exceptions are `ai1/octo.ai-aws-g6e` (L40S) and
+`ai1/octo.ai-aws-p5en` (H200 141 GB) for verified **low-priority preemptible**
+jobs only — both report `allowPreemptibleRestrictionExceptions: True` and reach S3.
 
 Pick one with free slots (`beaker cluster list ai1`); a job queues if none are
 free. Slot caps (Allocated = non-preemptible, Unallocated = preemptible) are in

--- a/code/check_gpu_availability.py
+++ b/code/check_gpu_availability.py
@@ -48,11 +48,18 @@ import shutil
 import subprocess
 import sys
 
-# Beaker hub clusters we are allowed to use (see beaker-launch skill).
+# Beaker hub clusters we are allowed to use (see beaker-launch skill / AGENTS.md §10).
+# All known hub pools + the one verified non-hub exception. Dev pools
+# (octo-hub-aws-l40s-dev, aihub-dev-aws) are intentionally omitted — we never
+# submit to them (AGENTS.md §10).
 BEAKER_HUB_CLUSTERS = [
-    "ai1/octo.ai-aws-g6e",       # L40S 48GB — low/preemptible-only (verified exception)
+    "ai1/octo.ai-aws-g6e",       # L40S 48GB  — non-hub; low/preemptible-only (verified exception)
+    "ai1/octo.ai-aws-p5en",      # H200 141GB — non-hub; low/preemptible-only (verified exception)
     "ai1/octo-hub-aws-l40s",     # L40S 48GB
-    "ai1/octo-hub-onprem-h200",  # H200 141GB — needed only for wide H256 (memory, not speed)
+    "ai1/octo-hub-aws-h200",     # H200 141GB
+    "ai1/octo-hub-gcp-h100",     # H100 80GB
+    "ai1/octo-hub-onprem-h200",  # H200 141GB — needed for wide H256 (memory, not speed)
+    "ai1/octo.hub-gcp-h200",     # H200 141GB
 ]
 HPC_GPU_PARTITION = "aind"
 


### PR DESCRIPTION
## Summary
Three related Beaker scheduling/tooling updates, landed as a clean commit series.

1. **`feat(check-gpu)`** — expand `check_gpu_availability.py` `BEAKER_HUB_CLUSTERS` from 3 to all known hub pools (adds `octo-hub-aws-h200`, `octo-hub-gcp-h100`, `octo.hub-gcp-h200`) + the verified non-hub exception `octo.ai-aws-p5en`. Previously it omitted the two pools that most often have room.
2. **`docs(beaker-launch)`** — document the beaker-py sandbox install (the prereqs assumed it was present): `uv` venv + pin `beaker-py<2` (2.x drops `from beaker import Beaker, Config`), plus the `$BEAKER_TOKEN` export the checker needs.
3. **`docs(beaker)`** — add `octo.ai-aws-p5en` as a second **verified** preemptible exception (probe: `allowPreemptibleRestrictionExceptions: True`, identical to g6e; H200 141GB, 3×8=24 slots — the preemptible route to H200 memory), and document the workspace's **three job-protection tiers** (4 allocated / 8 unallocated / ~unlimited low-preemptible) as one crisp statement.

## Verification
- p5en exception confirmed live: `beaker cluster get ai1/octo.ai-aws-p5en` → `allowPreemptibleRestrictionExceptions: True`.
- `maxWorkloadPriority=high` confirmed live (2026-07-12). The 4/8 slot figures are from the 2026-06-22 measurement — the beaker CLI does not expose the workspace slot budget, noted as such in the docs.
- Updated `check_gpu_availability.py` runs clean and lists all 7 clusters incl p5en.

## Notes
- Skill files under `aind-behavior-foundation-model-skills/` changed; installed-plugin consumers need `/plugin marketplace update` + `/reload-plugins` to pick these up (consider a `plugin.json` version bump on merge).
- Base is `ai_hub_pck_integration` (the active integration line), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WReHDhDFAfXXDN7Jxh8Grm