### PR TITLE
fix: pin study-02 W&B groups; launcher + skill fixes from end-to-end validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Code Ocean specific files and directories
 /data/
 /results/
+results/
 /scratch/
 metadata/metadata.yml
 

--- a/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
+++ b/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aind-behavior-foundation-model-skills",
   "description": "Agent Skills for the AIND behavior foundation model stack: codebase orientation for the disRNN dispatcher/wrapper repos, launching jobs on Beaker (AI Hub) and Allen on-prem SLURM HPC, study/variant organization, and post-hoc analysis reporting conventions.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Han Hou",
     "email": "houhan@gmail.com"

--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
@@ -21,7 +21,18 @@ resumable mechanics).
    (it only submits), the training is not.
 3. Use the `disrnn-cpu` conda env for `wandb`/`beaker`/YAML tooling:
    `conda activate disrnn-cpu` (`/allen/aind/scratch/han.hou/miniforge3/envs/disrnn-cpu`).
+   **It needs `beaker-py<2`** — the launchers and `check_gpu_availability.py` do
+   `from beaker import Beaker, Config`, and beaker-py 2.x dropped the `Config`
+   export (`ImportError: cannot import name 'Config'`). If beaker-py is missing
+   entirely (it was on HPC until 2026-07-11), `pip install "beaker-py<2"`.
+   The `beaker` CLI is not a substitute: the launchers use beaker-py directly so
+   the same code path works in the Mac sandbox, which has no CLI.
 4. Workspace/budget: `WS=ai1/aind-dynamic-foraging-foundation-model`.
+5. From HPC/sandbox, **pass `--output-dir`** to the launchers (or rely on the
+   repo-local `results/` fallback) — `/results` is the Code Ocean path.
+   Credentials on HPC: `BEAKER_TOKEN` is *not* in the env; read it from
+   `~/.beaker/config.yml` (`user_token`). `WANDB_API_KEY` likewise comes from
+   `~/.netrc`.
 
 ## Check available resources FIRST (mandatory for large jobs)
 

--- a/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
@@ -19,6 +19,9 @@ README wins.**
    (`../aind-disrnn-wrapper`); override with `--wrapper-root`.
 4. One-time setup per user: `cp code/hpc/slurm/user.env.example code/hpc/slurm/user.env`
    and edit (`SBATCH_*` vars for sbatch, `CONDA_SH` for env activation).
+5. Credentials on HPC live in files, not the env: W&B in `~/.netrc` (the SDK reads it;
+   producers using the GraphQL route need `WANDB_API_KEY` exported — see the
+   posthoc-reporting skill) and Beaker in `~/.beaker/config.yml`.
 
 ## Check available resources FIRST (mandatory for large jobs)
 

--- a/aind-behavior-foundation-model-skills/skills/posthoc-reporting/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/posthoc-reporting/SKILL.md
@@ -18,7 +18,39 @@ than inventing layout.
 3. **Caches are `.gitignore`'d** — anything re-derivable from W&B (per-subject pulls,
    `analysis/_cache_*.json`). Curated summary JSON and reports/figures are committed.
 4. **Provenance lives inside the artifact** — JSON `_meta`, report frontmatter.
-5. **Idempotent regeneration** — `make r<n>` twice produces identical files.
+5. **Idempotent regeneration** — `make r<n>` twice produces identical files
+   (see the caveats below: `_meta` timestamps and cross-machine figure bytes).
+
+## Pin the W&B groups — never discover them live (hard rule)
+
+A producer MUST read runs from a **declared allowlist** of W&B groups
+(`WANDB_GROUPS = [...]` at module level, queried per group, as in
+`studies/01-gru-scaling-law/analysis/nxd_scaling.py`). It must NOT query the whole
+project and keep whatever matches its grid.
+
+Why: a project-wide query silently absorbs **any** new run that happens to fit the
+cell definition, so a report's numbers change when someone launches something
+unrelated. This actually happened — `02-gru-scaling-law-ignore/analysis/scaling.py`
+globbed the project, and a 200-step validation smoke run moved its published H16
+mean from 0.71635 to 0.70348 (SEM 5.3e-5 → 1.3e-2) with no code change. Pinned
+producers (studies 01/03/04) ignored the same run and reproduced exactly.
+
+`_meta.wandb_groups` must be a subset of the declared allowlist — never a set
+discovered from whatever the query returned, which makes a contaminated pull look
+self-consistent.
+
+## What "reproducible" actually means here (verified 2026-07-11)
+
+- **Data (curated JSON/CSV) is exactly reproducible** — a re-run changes nothing but
+  `_meta`. This is the thing to check: `git diff` the JSON, ignore `_meta`, expect zero.
+- **`_meta.produced_at_pt` (and `dispatcher_git_sha`) change every run**, so
+  regeneration always dirties the tree. A CI check cannot be a bare
+  `git diff --exit-code` — it must ignore `_meta`.
+- **Figure PNGs are bit-identical only on the same machine.** Across machines the
+  bytes (and ~6% of pixels — text/AA rendering) differ, because the *plotting* env
+  is not pinned: `environment.lock` pins the wrapper commit that produced the
+  *metrics*, not matplotlib/freetype. A PNG diff after regenerating on a different
+  box is expected and is **not** evidence that results changed — confirm via the JSON.
 
 ## Layout (per study)
 

--- a/aind-behavior-foundation-model-skills/skills/posthoc-reporting/references/wandb-graphql-sandbox.md
+++ b/aind-behavior-foundation-model-skills/skills/posthoc-reporting/references/wandb-graphql-sandbox.md
@@ -1,10 +1,18 @@
 # Reading W&B from the Claude Science sandbox (GraphQL, no SDK)
 
-Producer scripts run on the HPC node (or any authenticated machine) where the
-`wandb` SDK works normally — nothing special needed there. **But** in the Claude
-Science Mac sandbox, `wandb.Api()` fails: it tries to spawn a `wandb-core` helper
-subprocess (`ServicePollForTokenError`) and write config under `~/.config/wandb`,
-both blocked. Working route:
+**On HPC, export `WANDB_API_KEY` before running any producer.** Several producers
+(e.g. `02-gru-scaling-law-ignore/analysis/scaling.py`) use the GraphQL route below
+and read `os.environ["WANDB_API_KEY"]` directly, so `make all` dies with
+`KeyError: 'WANDB_API_KEY'` even though the machine is authenticated — HPC auth
+lives in `~/.netrc`, which only the SDK consults:
+
+```bash
+export WANDB_API_KEY=$(grep -A2 'api.wandb.ai' ~/.netrc | grep password | awk '{print $2}')
+```
+
+In the Claude Science Mac sandbox, `wandb.Api()` fails outright: it tries to spawn a
+`wandb-core` helper subprocess (`ServicePollForTokenError`) and write config under
+`~/.config/wandb`, both blocked. Working route:
 
 - Store the key as the `WANDB_API_KEY` credential; hit the GraphQL endpoint
   directly with `requests`, `auth=('api', KEY)` — no SDK.

--- a/code/check_gpu_availability.py
+++ b/code/check_gpu_availability.py
@@ -53,6 +53,8 @@ BEAKER_HUB_CLUSTERS = [
     "ai1/octo.ai-aws-g6e",       # L40S 48GB — low/preemptible-only (verified exception)
     "ai1/octo-hub-aws-l40s",     # L40S 48GB
     "ai1/octo-hub-onprem-h200",  # H200 141GB — needed only for wide H256 (memory, not speed)
+    "ai1/octo-hub-aws-h200",     # H200 141GB — hub; was missing here, so the check
+                                 # under-reported capacity (31 free slots unseen 2026-07-11)
 ]
 HPC_GPU_PARTITION = "aind"
 

--- a/code/launch_beaker_resumable.py
+++ b/code/launch_beaker_resumable.py
@@ -38,6 +38,7 @@ import argparse
 import copy
 import hashlib
 import itertools
+import os
 import json
 import re
 import shutil
@@ -54,7 +55,11 @@ import yaml
 from beaker_client import submit_beaker_experiment
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-RESULTS = Path("/results")
+# Where the launch record is written. /results is the Code Ocean capsule path; it does not
+# exist (and is not writable) on the HPC login node or the Claude Science Mac sandbox, where
+# the launcher also runs, so fall back to a repo-local dir there instead of dying with
+# PermissionError: [Errno 13] '/results'. Override with --output-dir.
+RESULTS = Path("/results") if os.access("/results", os.W_OK) else REPO_ROOT / "results"
 
 # Stable path (per task's own /results dataset) where run_hpc anchors outputs so
 # autoResume restarts re-find their checkpoints. See run_hpc.py.

--- a/studies/02-gru-scaling-law-ignore/analysis/reports/r1-lr-engaged-scaling.md
+++ b/studies/02-gru-scaling-law-ignore/analysis/reports/r1-lr-engaged-scaling.md
@@ -37,7 +37,7 @@ reproduce: make -C studies/ignore-trials-scaling r1
 
 ![3-way L/R-engaged scaling](../fig_scaling.png)
 
-*Held-out conditional L/R likelihood on **engaged trials** vs # training mice (D), per hidden size H. Solid = 3-way (L/R/ignore) model; faded dashed = 2-way reference from `data-scaling-law`. Error bars: SEM (n=3 seeds/cell).*
+*Held-out conditional L/R likelihood on **engaged trials** vs # training mice (D), per hidden size H. Solid = 3-way (L/R/ignore) model; faded dashed = 2-way reference from `01-gru-scaling-law`. Error bars: SEM (n=3 seeds/cell).*
 
 Mean held-out L/R-engaged likelihood (3-way model):
 

--- a/studies/02-gru-scaling-law-ignore/analysis/scaling.json
+++ b/studies/02-gru-scaling-law-ignore/analysis/scaling.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
     "produced_by": "analysis/scaling.py",
-    "produced_at_pt": "2026-07-11T11:55:46-07:00",
-    "dispatcher_git_sha": "0c3e79615e70129540c5bc1a34a903d94bb91d70",
+    "produced_at_pt": "2026-07-12T13:41:59-07:00",
+    "dispatcher_git_sha": "8106160cb15ce128f8c4106a880a1f4599f62902",
     "wrapper_git_sha": "0a9141b0732d869ec312d4d15d7bcd1bc1eda933",
     "wandb_groups": [
       "nxd-3way@20260704-205230",

--- a/studies/02-gru-scaling-law-ignore/analysis/scaling.py
+++ b/studies/02-gru-scaling-law-ignore/analysis/scaling.py
@@ -38,6 +38,30 @@ from _meta import build_meta                            # noqa: E402
 # we require the run to have a resolved (D,H,seed) + a finished held-out metric.
 SWEEPS = {"o9oq3j4y", "9iu2rcap", "95br9evz", "4aq30mvb"}
 ENTITY, PROJECT = "AIND-disRNN", "mice_ignore_scaling"
+
+# The W&B groups this study is built from. This allowlist is the ONLY source of
+# runs: a run outside it is ignored no matter how well it matches (D,H,seed).
+# Without it the project-wide query below silently absorbs ANY new run that
+# happens to fit the grid -- a 200-step smoke run moved the published H16 mean
+# from 0.71635 to 0.70348 (SEM 5.3e-5 -> 1.3e-2) during the 2026-07-11 skills
+# validation. Pinning here matches studies 01/03/04 and makes the report
+# reproducible from committed code + pinned groups. Add a group when a launch
+# legitimately extends the grid.
+WANDB_GROUPS = [
+    "nxd-3way@20260704-205230",
+    "nxd-3way@20260704-205239",
+    "nxd-3way@20260707-075359",
+    "nxd-3way@20260707-075401",
+    "nxd-3way@20260707-075406",
+    "nxd-3way@20260707-075412",
+    "nxd-3way@20260707-110227",
+    "nxd-3way@20260707-110245",
+    "nxd-3way@20260708-231204",
+    "nxd-3way@20260708-231938",
+    "nxd-3way@20260709-231516",
+    "rerun_H16D10s2@20260705-104925",
+    "sweep-validate-capnsteps@20260710-183333",
+]
 SR_TO_D = {0.016: 10, 0.049: 30, 0.163: 100, 1.0: 614}
 HS = [16, 64, 128, 256]
 
@@ -100,6 +124,8 @@ def fetch_3way(first=500):
     best = {}  # (D,H,seed) -> (step, {metric: value})
     for e in r["data"]["project"]["runs"]["edges"]:
         n = e["node"]
+        if n.get("group") not in WANDB_GROUPS:
+            continue  # pinned allowlist: never absorb runs this study didn't declare
         cfg = json.loads(n["config"] or "{}")
         sm = json.loads(n["summaryMetrics"] or "{}")
         H = _get_nested(cfg, "model.architecture.hidden_size")
@@ -280,6 +306,9 @@ def main():
                 "ignore_pr_auc": {"mean": pa, "sem": pas, "ci95": paci, "n": max(n_pa, n_rc)},
                 "ignore_recall": {"mean": rc, "sem": rcs, "ci95": rcci, "n": max(n_pa, n_rc)},
             }
+    # Report the groups that actually contributed a kept run. These are a subset of
+    # the pinned WANDB_GROUPS allowlist by construction, so _meta can never advertise
+    # a group the study never declared.
     groups = sorted(getattr(fetch_3way, "groups", set()))
     out = {
         "_meta": build_meta("analysis/scaling.py", groups, study_root=STUDY),


### PR DESCRIPTION
Found by validating the codebase + skills end-to-end before the merge to `main`: launched a smoke job per study (01–04) on **both** Beaker and HPC SLURM, and regenerated every study's figures, following the skills verbatim.

**Validation result: 8/8 launches succeeded** (4 Beaker + 4 HPC), all logging to W&B with correct `<variant>@<launch_id>` groups and full `DISRNN_META_*` provenance. The 8 throwaway smoke runs have been deleted from W&B (confirmed 0 remaining). But the run surfaced one real bug and several gaps:

### 1. `fix(02-ignore)`: producer contaminated its own published results
`scaling.py` queried the whole `mice_ignore_scaling` project and kept any run resolving to a `(D,H,seed)` cell, then back-filled `_meta.wandb_groups` from whatever it kept. My **200-step smoke run was absorbed** and moved the published H16 mean **0.71635 → 0.70348** (SEM 5.3e-5 → 1.3e-2) with no code change.

Fixed by pinning to a `WANDB_GROUPS` allowlist (the 13 groups the report already declared), matching studies 01/03/04. **Verified:** with the smoke runs still live in W&B, regeneration restored the committed numbers exactly (0 non-`_meta` diff). Studies 01/03/04 pin correctly and were never affected.

The r1 caption also picks up the post-rename study name (`data-scaling-law` → `01-gru-scaling-law`), stale since the folder rename.

### 2. `fix(launch)`: two bugs in the documented commands
- `check_gpu_availability.py` omitted **`ai1/octo-hub-aws-h200`** from `BEAKER_HUB_CLUSTERS` — the check AGENTS.md §10 makes *mandatory* hid **24 schedulable H200 GPUs** while the other clusters read 0/0/8, which would push a large fan-out to HPC for no reason.
- `launch_beaker_resumable.py` defaulted `--output-dir` to `/results` (a Code Ocean path) → `PermissionError` on the HPC login node, and the skill's example command doesn't pass the flag. Now falls back to a repo-local `results/` when `/results` isn't writable.

### 3. `docs(skills)`: fold in what validation taught
- **beaker-launch**: `disrnn-cpu` had **no beaker-py at all** on HPC (so the launchers + capacity check crashed), and beaker-py **2.x breaks** `from beaker import Beaker, Config` → pin **`beaker-py<2`**. Credentials aren't in the HPC env (they're in `~/.beaker/config.yml` / `~/.netrc`).
- **posthoc-reporting**: new hard rule — producers must read a *declared* group allowlist, never glob the project. Replaced the bare "idempotent regeneration" claim with the verified truth: data reproduces exactly; `_meta` timestamps always change (so CI can't be a bare `git diff --exit-code`); figure bytes match only on the same machine (plotting env is unpinned — `environment.lock` pins the *wrapper* commit, not matplotlib).
- **posthoc-reporting / hpc-launch**: producers using the GraphQL route need `WANDB_API_KEY` exported on HPC; `make all` died with `KeyError` because HPC auth lives in `~/.netrc`.

Plugin bumped 0.5.0 → 0.6.0.

Known gap left open (not fixed here): study 01's `make all` takes >10 min (re-pulls W&B per target; `rl_baseline.py` runs 4×), and the plotting env is still unpinned.

**Merge, do not squash.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)