### PR TITLE
docs(skills): retarget PR flow to main (ai_hub_pck_integration retired)

### DIFF
--- a/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
+++ b/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aind-behavior-foundation-model-skills",
   "description": "Agent Skills for the AIND behavior foundation model stack: codebase orientation for the disRNN dispatcher/wrapper repos, launching jobs on Beaker (AI Hub) and Allen on-prem SLURM HPC, study/variant organization, and post-hoc analysis reporting conventions.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Han Hou",
     "email": "houhan@gmail.com"

--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/references/sandbox-launch.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/references/sandbox-launch.md
@@ -55,8 +55,8 @@ PYTHONPATH="$(pwd):$PYTHONPATH" python launch_beaker.py \
 
 Old example specs (`experiment_h100.yaml`, `experiment_h200.yaml`,
 `experiment_pack.yaml`) reference `beaker: han-hou/disrnn-wrapper`, which **no
-longer exists** -> `ImageNotFound`/404. Current image for the
-`ai_hub_pck_integration` line: `han-hou/disrnn-wrapper-pck-integration-20260630` —
+longer exists** -> `ImageNotFound`/404. Current image:
+`han-hou/disrnn-wrapper-pck-integration-20260630` —
 it ships the newer `aind-dynamic-foraging-database` with
 `select_sessions(snapshot=...)` support; the older `...-pck-integration`
 (2026-06-18) fails on the `mice_snapshot_scaling` data path

--- a/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
@@ -65,5 +65,5 @@ in `AGENTS.md` §8).
 - `references/study-wrapup.md` — the verified end-to-end procedure for closing out
   a finished study: normalize the folder, clean launch records, clean stale W&B
   runs (irreversible — confirm first), the two-repo PR flow to
-  `ai_hub_pck_integration` (wrapper first, never squash), branch retirement, and
+  `main` (wrapper first, never squash), branch retirement, and
   the `git mv` re-staging trap.

--- a/aind-behavior-foundation-model-skills/skills/study-conventions/references/study-wrapup.md
+++ b/aind-behavior-foundation-model-skills/skills/study-conventions/references/study-wrapup.md
@@ -48,7 +48,7 @@ A study is a **two-repo deliverable**: the dispatcher carries `studies/<study>/`
 (control plane), and the **wrapper** carries the study's *training payload* — the
 data loader, its tests, and any model-agnostic analysis script the study added
 (e.g. `code/data_loaders/<gen>.py`, `code/analysis/<study>_recovery.py`, plus any
-`run_hpc.py` change). **Both need a PR to `ai_hub_pck_integration`**, and the
+`run_hpc.py` change). **Both need a PR to `main`**, and the
 dispatcher's `environment.lock` pins a wrapper commit, so the wrapper payload must
 land too — don't stop at the dispatcher.
 


### PR DESCRIPTION
## What
`ai_hub_pck_integration` was merged to `main` (#53) and retired, so the skill docs that still name it as the integration/PR target are stale. Retarget them to `main`.

## Changes
- `study-conventions/SKILL.md` + `references/study-wrapup.md` — the two-repo study PR flow now targets **`main`** (was `ai_hub_pck_integration`).
- `beaker-launch/references/sandbox-launch.md` — drop the stale "`ai_hub_pck_integration` line" qualifier on the current wrapper-image note (image name unchanged).
- `plugin.json` 0.6.0 → 0.6.1.

## Left as-is (intentional)
`docs/repo-split-plan.md` still references `ai_hub_pck_integration` in three places — those are **historical point-in-time snapshots** (commit `122abfd`, "35 commits ahead"), archival record of the repo split, not operational guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WReHDhDFAfXXDN7Jxh8Grm