### PR TITLE
feat(beaker): pin runtime refs before submission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,12 +203,12 @@ Full scheme — task-to-host table, W&B-from-sandbox access, credentials: the
 - **Verify the image name before submitting.** Old example specs
   (`experiment_h100/h200/pack.yaml`) reference `beaker: han-hou/disrnn-wrapper`,
   which no longer exists (→ `ImageNotFound`/404). Current:
-  `han-hou/disrnn-wrapper-pck-integration-20260630` (the older `...-pck-integration`
-  lacks `select_sessions(snapshot=...)` — see `code/beaker/README.md` "Available
+  `han-hou/disrnn-wrapper-main-20260712` (see `code/beaker/README.md` "Available
   images"); list live images with
   `beaker workspace images ai1/aind-dynamic-foraging-foundation-model`. Code is
-  pulled fresh at startup (`entrypoint.sh` checks out `WRAPPER_REF`/`DISPATCHER_REF`),
-  so code/config edits need **no** rebuild — only a stale image or changed deps do.
+  pulled fresh at startup (`entrypoint.sh` checks out `WRAPPER_REF`/`DISPATCHER_REF`/
+  `FORAGING_MODELS_REF`), so code/config edits need **no** rebuild — only a stale
+  image or changed dependencies do.
 - **Transient node failure ≠ code bug.** A job dying in ~5 s with
   `status.message: "no space left on device"` / `started=None` is a full-NVMe node;
   resubmit (lands elsewhere) instead of debugging training code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,13 @@ and is not allowed.
 - If you trigger jobs from Allen's HPC, use the `disrnn-cpu` conda env
   (`/allen/aind/scratch/han.hou/miniforge3/envs/disrnn-cpu`), not base. Treat this as the
   launcher/control-plane environment for `wandb`, `beaker`, and YAML tooling.
+- **Scientific Beaker jobs must submit immutable source refs.** Source templates may
+  use readable branch/tag values with inline comments, but both Beaker launchers
+  resolve `WRAPPER_REF`, `DISPATCHER_REF`, and `FORAGING_MODELS_REF` to full
+  40-character GitHub SHAs before creating a W&B sweep or submitting to Beaker; the
+  saved rendered YAML contains those SHAs. Mutable refs are only acceptable for
+  direct smoke/development jobs. If bypassing the launchers with
+  `beaker experiment create`, pin all three refs manually.
 - **Submit ONLY to `hub` clusters** (the team's pools: `octo-hub-*`, `octo.hub-*`, `aihub-*`).
   **NEVER** to non-hub clusters (`aipbd-*`, `siti-*`, `dev-*`, other `octo.ai-*`) even if idle
   — they're not ours. Verified exceptions (non-hub `octo.ai-aws-*`, but admit our

--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
@@ -34,6 +34,11 @@ resumable mechanics).
    Credentials on HPC: `BEAKER_TOKEN` is *not* in the env; read it from
    `~/.beaker/config.yml` (`user_token`). `WANDB_API_KEY` likewise comes from
    `~/.netrc`.
+6. **Scientific submissions use immutable refs.** Templates may retain readable
+   branch/tag values and inline comments, but the launchers require all three REF
+   variables and resolve them to full SHAs before W&B sweep creation or Beaker
+   submission. The rendered launch-record YAML is pinned. Mutable refs are only
+   for direct smoke/development jobs; pin manually when bypassing the launchers.
 
 ## Check available resources FIRST (mandatory for large jobs)
 

--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/references/sandbox-launch.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/references/sandbox-launch.md
@@ -56,8 +56,10 @@ PYTHONPATH="$(pwd):$PYTHONPATH" python launch_beaker.py \
 Old example specs (`experiment_h100.yaml`, `experiment_h200.yaml`,
 `experiment_pack.yaml`) reference `beaker: han-hou/disrnn-wrapper`, which **no
 longer exists** -> `ImageNotFound`/404. Current image:
-`han-hou/disrnn-wrapper-pck-integration-20260630` —
-it ships the newer `aind-dynamic-foraging-database` with
+`han-hou/disrnn-wrapper-main-20260712` — it defaults the wrapper, dispatcher,
+and foraging-models refs to `main`, refreshes all three at job startup, and
+records their resolved commits. It also ships `aind-dynamic-foraging-database`
+with
 `select_sessions(snapshot=...)` support; the older `...-pck-integration`
 (2026-06-18) fails on the `mice_snapshot_scaling` data path
 (`TypeError: ... unexpected keyword argument 'snapshot'`). The authoritative list
@@ -72,9 +74,10 @@ images and set the spec's `image.beaker` to one that exists:
 ```
 
 Code is pulled fresh at container startup (`entrypoint.sh` checks out
-`WRAPPER_REF`/`DISPATCHER_REF`), so **code/config edits need no image rebuild** —
-push the branch and set the refs. Rebuild only when pinned dependencies change (a
-code edit that calls a dependency with a *new* signature counts as a dependency
+`WRAPPER_REF`/`DISPATCHER_REF`/`FORAGING_MODELS_REF`), so **code/config edits need
+no image rebuild** — push the branch and set the refs. Rebuild only when pinned
+dependencies change (a code edit that calls a dependency with a *new* signature
+counts as a dependency
 change).
 
 ## Transient node failure != code bug

--- a/aind-behavior-foundation-model-skills/skills/codebase-map/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/codebase-map/SKILL.md
@@ -12,8 +12,9 @@ description: Orient in the aind-disrnn-dispatcher codebase — the two-repo arch
   Code Ocean, Beaker (AI Hub), or Allen on-prem SLURM HPC.
 - **`aind-disrnn-wrapper`** (expected as a sibling checkout at
   `../aind-disrnn-wrapper`) is the *compute/runtime payload*: training code, the
-  Beaker image, `run_hpc`. Job containers pull code fresh at startup, so code edits
-  need **no image rebuild** (pin via `WRAPPER_REF` / `DISPATCHER_REF`).
+  Beaker image, `run_hpc`. Job containers refresh the wrapper, dispatcher, and
+  `aind-dynamic-foraging-models` sources at startup, so code edits need **no image
+  rebuild** (pin via `WRAPPER_REF`, `DISPATCHER_REF`, and `FORAGING_MODELS_REF`).
 - W&B (`entity: AIND-disRNN`) is the experiment tracker across all backends.
 - **Claude Science layer** (AGENTS.md §13): the agent's persistent brain runs on the
   user's Mac; GitHub is the source of truth, tracked by the Mac authoring clone

--- a/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
@@ -56,9 +56,12 @@ in `AGENTS.md` §8).
 1. Create `studies/<study>/variants/<variant>/` with `sweep.yaml` + `experiment.yaml`
    (copy the closest existing variant).
 2. Write `notes.md`: what differs from the sibling variants and what you expect.
-3. Launch via the beaker-launch or hpc-launch skill with `--label` and `--note`.
-4. Add a row to the study README's Variants index.
-5. After the group settles, write `launch_record_<label>/results.md`
+3. Include `WRAPPER_REF`, `DISPATCHER_REF`, and `FORAGING_MODELS_REF` in the Beaker
+   YAML. Branch names may remain for readability; the launcher resolves all three
+   to full SHAs in the submitted launch record.
+4. Launch via the beaker-launch or hpc-launch skill with `--label` and `--note`.
+5. Add a row to the study README's Variants index.
+6. After the group settles, write `launch_record_<label>/results.md`
    (contract in the posthoc-reporting skill).
 
 ## References (read on demand)

--- a/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
@@ -46,9 +46,10 @@ in `AGENTS.md` §8).
 - **Always pass `--note`** ("why this run exists + what we want to learn") so the
   scientific intent is readable straight from the W&B record.
 - Platform-native ids are stamped alongside: `BEAKER_EXPERIMENT_ID`, `BEAKER_JOB_ID`,
-  `CO_COMPUTATION_ID`, plus `wrapper_commit` / `dispatcher_commit`. Both Beaker
-  launchers (`launch_beaker_resumable.py` and `launch_beaker.py`) implement this
-  identically.
+  `CO_COMPUTATION_ID`, plus `wrapper_commit`, `dispatcher_commit`, and
+  `foraging_models_commit`. Both Beaker launchers (`launch_beaker_resumable.py`
+  and `launch_beaker.py`) implement the portable launch metadata identically;
+  the wrapper records the resolved source commits.
 
 ## Checklist for a new variant launch
 

--- a/aind-behavior-foundation-model-skills/skills/study-conventions/references/study-wrapup.md
+++ b/aind-behavior-foundation-model-skills/skills/study-conventions/references/study-wrapup.md
@@ -1,7 +1,7 @@
 # Housekeeping: wrapping up a completed study
 
 When a study's experiments are done and results are settled: normalize the folder,
-clean up runs, and get the work onto the integration branch. Verified end-to-end
+clean up runs, and get the work onto `main`. Verified end-to-end
 procedure.
 
 ## 1. Normalize the study folder
@@ -42,7 +42,7 @@ then show the classified keep/delete list and get explicit confirmation before
 deleting. (GraphQL `deleteRun` payload has `clientMutationId` + `numDeleted`, not
 `success` — selecting `success` returns HTTP 400.)
 
-## 4. PR to the integration branch (BOTH repos)
+## 4. PR to `main` (BOTH repos)
 
 A study is a **two-repo deliverable**: the dispatcher carries `studies/<study>/`
 (control plane), and the **wrapper** carries the study's *training payload* — the

--- a/code/beaker/README.md
+++ b/code/beaker/README.md
@@ -113,7 +113,7 @@ the AI Hub `getting-started/budgets.md`.
 
 Large multisubject mice cohorts (`mice_snapshot_scaling`: ~600 subjects, ~18k
 sessions, ~9.7M trials) hit three distinct memory walls. All are fixed in the
-wrapper (branch `ai_hub_pck_integration`); notes here so they don't resurface.
+wrapper `main`; notes here so they don't resurface.
 
 1. **Slow load (host CPU), ~6–7 min.** `_build_multisubject_bundle` filtered
    `df[df["subject_id"] == sid]` once per subject over an object-dtype column —
@@ -296,7 +296,7 @@ GPUs that are free *and* not on a cordoned node, by type.
 
 **Image names go stale — verify before launching.** Old example specs referenced
 `beaker: han-hou/disrnn-wrapper`, which **no longer exists** (→ `ImageNotFound`/404).
-The current image for the `ai_hub_pck_integration` line is
+The current image for the `main` line is
 `han-hou/disrnn-wrapper-pck-integration-20260630` (see "Available images" above —
 the older `...-pck-integration` lacks `select_sessions(snapshot=...)`). List live
 images and point the spec's `image.beaker` at one that exists:
@@ -304,4 +304,3 @@ images and point the spec's `image.beaker` at one that exists:
 Python, `[im.full_name for im in b.workspace.images(workspace="ai1/aind-dynamic-foraging-foundation-model")]`.
 Because code is pulled fresh at startup, a stale image is the only thing here that
 needs fixing before launch — you almost never rebuild for a code change.
-

--- a/code/beaker/README.md
+++ b/code/beaker/README.md
@@ -150,12 +150,14 @@ L40s with the eval chunking above and `replicas`≤2.
 
 The image is built on a Mac and pushed to Beaker — see the wrapper's
 `beaker/README.md`. Code is pulled fresh at job startup, so **code edits need no
-rebuild**; control the branch/commit via `WRAPPER_REF` / `DISPATCHER_REF` in
-`experiment_mvp.yaml` (a branch name, or a SHA to pin a run).
+rebuild**; control the branch/commit via `WRAPPER_REF`, `DISPATCHER_REF`, and
+`FORAGING_MODELS_REF` in `experiment_mvp.yaml` (a branch name, or a SHA to pin a
+run). The resolved commits are recorded in W&B run provenance.
 
-**Rebuild is only needed for DEPENDENCY changes** (`pyproject.toml` / the pinned
-git deps). A code edit that starts calling a dependency with a *new* signature is
-effectively a dependency change: e.g. `load_mice_database.py` calling
+**Rebuild is only needed for DEPENDENCY changes** (`pyproject.toml`, including new
+dependencies introduced by dynamic foraging-models source, or pinned git deps).
+A code edit that starts calling a dependency with a *new* signature is effectively
+a dependency change: e.g. `load_mice_database.py` calling
 `select_sessions(snapshot=...)` requires a newer `aind-dynamic-foraging-database`
 than older images ship — an older image fails at data-load with
 `TypeError: select_sessions() got an unexpected keyword argument 'snapshot'`.
@@ -164,7 +166,8 @@ than older images ship — an older image fails at data-load with
 
 | image | built | notes |
 |---|---|---|
-| `han-hou/disrnn-wrapper-pck-integration-20260630` | 2026-07-01 | **current — use this.** Ships the newer `aind-dynamic-foraging-database` with `select_sessions(snapshot=...)` support (the `mice_snapshot_scaling` data path). |
+| `han-hou/disrnn-wrapper-main-20260712` | 2026-07-12 | **current — use this.** Defaults all runtime refs to `main`, refreshes foraging-models source at startup, and records its resolved commit. |
+| `han-hou/disrnn-wrapper-pck-integration-20260630` | 2026-07-01 | Previous dependency image; supports `select_sessions(snapshot=...)` but does not refresh foraging-models source. |
 | `han-hou/disrnn-wrapper-pck-integration` | 2026-06-18 | older; DB package predates `snapshot=` — fails on the snapshot data loader used by `data-scaling-law` / `ignore-trials` / `beta-scan`. Pin `WRAPPER_REF` to a commit whose `load_mice_database.py` calls `select_sessions` *without* `snapshot` (e.g. `4f296807`) if you must use it. |
 
 ## Scaling
@@ -297,8 +300,7 @@ GPUs that are free *and* not on a cordoned node, by type.
 **Image names go stale — verify before launching.** Old example specs referenced
 `beaker: han-hou/disrnn-wrapper`, which **no longer exists** (→ `ImageNotFound`/404).
 The current image for the `main` line is
-`han-hou/disrnn-wrapper-pck-integration-20260630` (see "Available images" above —
-the older `...-pck-integration` lacks `select_sessions(snapshot=...)`). List live
+`han-hou/disrnn-wrapper-main-20260712` (see "Available images" above). List live
 images and point the spec's `image.beaker` at one that exists:
 `beaker workspace images ai1/aind-dynamic-foraging-foundation-model` (CLI) or, in
 Python, `[im.full_name for im in b.workspace.images(workspace="ai1/aind-dynamic-foraging-foundation-model")]`.

--- a/code/beaker/README.md
+++ b/code/beaker/README.md
@@ -152,7 +152,12 @@ The image is built on a Mac and pushed to Beaker — see the wrapper's
 `beaker/README.md`. Code is pulled fresh at job startup, so **code edits need no
 rebuild**; control the branch/commit via `WRAPPER_REF`, `DISPATCHER_REF`, and
 `FORAGING_MODELS_REF` in `experiment_mvp.yaml` (a branch name, or a SHA to pin a
-run). The resolved commits are recorded in W&B run provenance.
+run). For scientific launches, keep readable branch names/comments in the source
+template if useful: both launchers resolve all three refs before creating the W&B
+sweep or submitting to Beaker, and save only full 40-character SHAs in the rendered
+`experiment*_submitted.yaml`. Direct smoke/development jobs may use mutable refs;
+pin all three manually if calling `beaker experiment create` for scientific work.
+The resolved commits are also recorded in W&B run provenance.
 
 **Rebuild is only needed for DEPENDENCY changes** (`pyproject.toml`, including new
 dependencies introduced by dynamic foraging-models source, or pinned git deps).

--- a/code/beaker/experiment_h100.yaml
+++ b/code/beaker/experiment_h100.yaml
@@ -35,10 +35,10 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: FORAGING_MODELS_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
     result:
       path: /results

--- a/code/beaker/experiment_h100.yaml
+++ b/code/beaker/experiment_h100.yaml
@@ -12,7 +12,7 @@ description: disRNN benchmark on one H100 (GCP)
 tasks:
   - name: disrnn-h100
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration   # current image; list live: beaker workspace images ai1/aind-dynamic-foraging-foundation-model
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -37,6 +37,8 @@ tasks:
       - name: WRAPPER_REF
         value: main
       - name: DISPATCHER_REF
+        value: main
+      - name: FORAGING_MODELS_REF
         value: main
     result:
       path: /results

--- a/code/beaker/experiment_h100.yaml
+++ b/code/beaker/experiment_h100.yaml
@@ -35,8 +35,8 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: ai_hub_pck_integration
+        value: main
       - name: DISPATCHER_REF
-        value: ai_hub_pck_integration
+        value: main
     result:
       path: /results

--- a/code/beaker/experiment_h200.yaml
+++ b/code/beaker/experiment_h200.yaml
@@ -35,10 +35,10 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: FORAGING_MODELS_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
     result:
       path: /results

--- a/code/beaker/experiment_h200.yaml
+++ b/code/beaker/experiment_h200.yaml
@@ -12,7 +12,7 @@ description: disRNN T4-match benchmark on one H200
 tasks:
   - name: disrnn-h200
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration   # current image; list live: beaker workspace images ai1/aind-dynamic-foraging-foundation-model
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -37,6 +37,8 @@ tasks:
       - name: WRAPPER_REF
         value: main
       - name: DISPATCHER_REF
+        value: main
+      - name: FORAGING_MODELS_REF
         value: main
     result:
       path: /results

--- a/code/beaker/experiment_h200.yaml
+++ b/code/beaker/experiment_h200.yaml
@@ -35,8 +35,8 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: ai_hub_pck_integration
+        value: main
       - name: DISPATCHER_REF
-        value: ai_hub_pck_integration
+        value: main
     result:
       path: /results

--- a/code/beaker/experiment_mvp.yaml
+++ b/code/beaker/experiment_mvp.yaml
@@ -10,10 +10,8 @@
 ##   <SWEEP_ID>   e.g. AIND-disRNN/ai_hub_test/abc123
 ##                (from `wandb sweep code/beaker/sweep_mvp.yaml`)
 ##
-## Submit:
-##   beaker experiment create \
-##     -w ai1/aind-dynamic-foraging-foundation-model \
-##     code/beaker/experiment_mvp.yaml
+## Launch through `code/launch_beaker.py`; it renders <SWEEP_ID>, resolves all
+## runtime refs to full SHAs, saves the submitted spec, and submits to Beaker.
 
 version: v2
 description: disRNN MVP — synthetic-RL -> disRNN, one W&B sweep agent
@@ -47,10 +45,10 @@ tasks:
         value: /results
       # branch/tag/SHA to run; a SHA pins for reproducibility
       - name: WRAPPER_REF
-        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
+        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c  # main
       - name: DISPATCHER_REF
-        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
+        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23  # main
       - name: FORAGING_MODELS_REF
-        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e
+        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e  # main
     result:
       path: /results

--- a/code/beaker/experiment_mvp.yaml
+++ b/code/beaker/experiment_mvp.yaml
@@ -46,8 +46,8 @@ tasks:
         value: /results
       # branch/tag/SHA to run; a SHA pins for reproducibility
       - name: WRAPPER_REF
-        value: ai_hub_pck_integration
+        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
       - name: DISPATCHER_REF
-        value: ai_hub_pck_integration
+        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
     result:
       path: /results

--- a/code/beaker/experiment_mvp.yaml
+++ b/code/beaker/experiment_mvp.yaml
@@ -2,8 +2,9 @@
 ##
 ## Dispatcher control-plane artifact: the Beaker job the dispatcher launches.
 ## The image is built/maintained in the wrapper repo
-## (aind-disrnn-wrapper/beaker) and clones both repos at runtime, so this spec
-## never needs the image rebuilt for code changes.
+## (aind-disrnn-wrapper/beaker) and refreshes the wrapper, dispatcher, and
+## foraging-models repos at runtime, so this spec never needs the image rebuilt
+## for code changes.
 ##
 ## Fill before submitting:
 ##   <SWEEP_ID>   e.g. AIND-disRNN/ai_hub_test/abc123
@@ -19,9 +20,9 @@ description: disRNN MVP — synthetic-RL -> disRNN, one W&B sweep agent
 tasks:
   - name: disrnn-mvp
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration   # from `beaker image get disrnn-wrapper`
+      beaker: han-hou/disrnn-wrapper-main-20260712
     # entrypoint.sh pulls the latest code at container startup, then runs
-    # `wandb agent`. Control the code version via WRAPPER_REF/DISPATCHER_REF.
+    # `wandb agent`. Control source versions via the three REF variables below.
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -49,5 +50,7 @@ tasks:
         value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
       - name: DISPATCHER_REF
         value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
+      - name: FORAGING_MODELS_REF
+        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e
     result:
       path: /results

--- a/code/beaker/experiment_pack.yaml
+++ b/code/beaker/experiment_pack.yaml
@@ -13,7 +13,7 @@ description: disRNN GPU packing — M wandb agents time-sliced on one GPU
 tasks:
   - name: disrnn-pack
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration   # current image; list live: beaker workspace images ai1/aind-dynamic-foraging-foundation-model
+      beaker: han-hou/disrnn-wrapper-main-20260712
     # entrypoint pulls code, then pack_gpu.sh launches <PACK_M> agents here.
     command:
       - bash
@@ -39,5 +39,7 @@ tasks:
         value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
       - name: DISPATCHER_REF
         value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
+      - name: FORAGING_MODELS_REF
+        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e
     result:
       path: /results

--- a/code/beaker/experiment_pack.yaml
+++ b/code/beaker/experiment_pack.yaml
@@ -36,8 +36,8 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: ai_hub_pck_integration
+        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
       - name: DISPATCHER_REF
-        value: ai_hub_pck_integration
+        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
     result:
       path: /results

--- a/code/beaker/experiment_pack.yaml
+++ b/code/beaker/experiment_pack.yaml
@@ -36,10 +36,10 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
+        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c  # main
       - name: DISPATCHER_REF
-        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
+        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23  # main
       - name: FORAGING_MODELS_REF
-        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e
+        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e  # main
     result:
       path: /results

--- a/code/beaker/experiment_recovery_disrnn.yaml
+++ b/code/beaker/experiment_recovery_disrnn.yaml
@@ -1,7 +1,7 @@
 ## Beaker spec — embedding-recovery disRNN grid on ai1/octo.ai-aws-p5en (H100).
 ## N wandb-agent replicas drain one shared sweep (the disrnn-stage4a 6-cell grid).
-## The entrypoint refreshes both repos to the refs below at container startup, so pushing
-## feat/embedding-recovery is enough (no image rebuild for code/config).
+## The entrypoint refreshes both repos to the merged main SHAs below at container startup,
+## so code/config changes need no image rebuild.
 ## The launcher renders <SWEEP_ID> at submit.
 ##
 ## IMPORTANT image note: use the 20260630 image — the older han-hou/disrnn-wrapper-pck-integration
@@ -34,8 +34,8 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: feat/embedding-recovery
+        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
       - name: DISPATCHER_REF
-        value: feat/embedding-recovery
+        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
     result:
       path: /results

--- a/code/beaker/experiment_recovery_disrnn.yaml
+++ b/code/beaker/experiment_recovery_disrnn.yaml
@@ -33,10 +33,10 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
+        value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c  # main
       - name: DISPATCHER_REF
-        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
+        value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23  # main
       - name: FORAGING_MODELS_REF
-        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e
+        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e  # main
     result:
       path: /results

--- a/code/beaker/experiment_recovery_disrnn.yaml
+++ b/code/beaker/experiment_recovery_disrnn.yaml
@@ -1,18 +1,17 @@
 ## Beaker spec — embedding-recovery disRNN grid on ai1/octo.ai-aws-p5en (H100).
 ## N wandb-agent replicas drain one shared sweep (the disrnn-stage4a 6-cell grid).
-## The entrypoint refreshes both repos to the merged main SHAs below at container startup,
-## so code/config changes need no image rebuild.
+## The entrypoint refreshes all three source repos to the SHAs below at container
+## startup, so code/config changes need no image rebuild.
 ## The launcher renders <SWEEP_ID> at submit.
 ##
-## IMPORTANT image note: use the 20260630 image — the older han-hou/disrnn-wrapper-pck-integration
-## (2026-06-18) bakes a stale aind_dynamic_foraging_database==0.0.5 that breaks data-load;
-## the entrypoint refreshes CODE but not pip deps, so the image must carry the fixed deps.
+## IMPORTANT image note: use the main-20260712 image, which carries the current
+## dependency environment and refreshes foraging-models source at startup.
 version: v2
 description: embedding-recovery disRNN stage4a (mixture of model families) — p5en H100
 tasks:
   - name: recovery-disrnn-stage4a
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -37,5 +36,7 @@ tasks:
         value: 0e95f807c22eb90266ffd6ee5545289d91c1b42c
       - name: DISPATCHER_REF
         value: 7c3ae59d6adaf1f16f9b9a50fda55cb286a9df23
+      - name: FORAGING_MODELS_REF
+        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e
     result:
       path: /results

--- a/code/beaker/experiment_recovery_disrnn_h200.yaml
+++ b/code/beaker/experiment_recovery_disrnn_h200.yaml
@@ -34,10 +34,10 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: FORAGING_MODELS_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
     result:
       path: /results

--- a/code/beaker/experiment_recovery_disrnn_h200.yaml
+++ b/code/beaker/experiment_recovery_disrnn_h200.yaml
@@ -1,7 +1,7 @@
 ## Beaker spec — embedding-recovery disRNN grid on ai1/octo-hub-onprem-h200 (H100).
 ## N wandb-agent replicas drain one shared sweep (the disrnn-stage4a 6-cell grid).
-## The entrypoint refreshes both repos to the refs below at container startup, so pushing
-## feat/embedding-recovery is enough (no image rebuild for code/config).
+## The entrypoint refreshes both repos to the refs below at container startup, so
+## code/config changes need no image rebuild.
 ## The launcher renders <SWEEP_ID> at submit.
 ##
 ## IMPORTANT image note: use the 20260630 image — the older han-hou/disrnn-wrapper-pck-integration
@@ -35,8 +35,8 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: feat/embedding-recovery
+        value: main
       - name: DISPATCHER_REF
-        value: feat/embedding-recovery
+        value: main
     result:
       path: /results

--- a/code/beaker/experiment_recovery_disrnn_h200.yaml
+++ b/code/beaker/experiment_recovery_disrnn_h200.yaml
@@ -1,18 +1,17 @@
 ## Beaker spec — embedding-recovery disRNN grid on ai1/octo-hub-onprem-h200 (H100).
 ## N wandb-agent replicas drain one shared sweep (the disrnn-stage4a 6-cell grid).
-## The entrypoint refreshes both repos to the refs below at container startup, so
-## code/config changes need no image rebuild.
+## The entrypoint refreshes all three source repos to the refs below at container
+## startup, so code/config changes need no image rebuild.
 ## The launcher renders <SWEEP_ID> at submit.
 ##
-## IMPORTANT image note: use the 20260630 image — the older han-hou/disrnn-wrapper-pck-integration
-## (2026-06-18) bakes a stale aind_dynamic_foraging_database==0.0.5 that breaks data-load;
-## the entrypoint refreshes CODE but not pip deps, so the image must carry the fixed deps.
+## IMPORTANT image note: use the main-20260712 image, which carries the current
+## dependency environment and refreshes foraging-models source at startup.
 version: v2
 description: embedding-recovery disRNN stage4a (mixture of model families) — onprem-H200 (non-preemptible)
 tasks:
   - name: recovery-disrnn-stage4a
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -37,6 +36,8 @@ tasks:
       - name: WRAPPER_REF
         value: main
       - name: DISPATCHER_REF
+        value: main
+      - name: FORAGING_MODELS_REF
         value: main
     result:
       path: /results

--- a/code/beaker/experiment_recovery_smoke.yaml
+++ b/code/beaker/experiment_recovery_smoke.yaml
@@ -1,7 +1,7 @@
 ## Beaker spec — embedding-recovery SMOKE on one gcp-h100 GPU.
 ## Validates the hierarchical-synthetic -> multisubject-GRU -> recovery path.
 ## The entrypoint refreshes both repos to the refs below at container startup,
-## so pushing feat/embedding-recovery is enough (no image rebuild for code/config).
+## so code/config changes need no image rebuild.
 ## The launcher renders <SWEEP_ID> at submit.
 ##
 ## Launch (from hpc-code login node, dispatcher repo root):
@@ -15,7 +15,7 @@ description: embedding-recovery smoke (hierarchical synthetic + multisubject GRU
 tasks:
   - name: recovery-smoke-gru
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration  # current image for the ai_hub_pck_integration line
+      beaker: han-hou/disrnn-wrapper-pck-integration  # current image for the main line
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -38,8 +38,8 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: feat/embedding-recovery
+        value: main
       - name: DISPATCHER_REF
-        value: feat/embedding-recovery
+        value: main
     result:
       path: /results

--- a/code/beaker/experiment_recovery_smoke.yaml
+++ b/code/beaker/experiment_recovery_smoke.yaml
@@ -38,10 +38,10 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: main
+        value: main  # smoke may also be submitted directly with this mutable ref
       - name: DISPATCHER_REF
-        value: main
+        value: main  # smoke may also be submitted directly with this mutable ref
       - name: FORAGING_MODELS_REF
-        value: main
+        value: main  # smoke may also be submitted directly with this mutable ref
     result:
       path: /results

--- a/code/beaker/experiment_recovery_smoke.yaml
+++ b/code/beaker/experiment_recovery_smoke.yaml
@@ -1,7 +1,7 @@
 ## Beaker spec — embedding-recovery SMOKE on one gcp-h100 GPU.
 ## Validates the hierarchical-synthetic -> multisubject-GRU -> recovery path.
-## The entrypoint refreshes both repos to the refs below at container startup,
-## so code/config changes need no image rebuild.
+## The entrypoint refreshes all three source repos to the refs below at container
+## startup, so code/config changes need no image rebuild.
 ## The launcher renders <SWEEP_ID> at submit.
 ##
 ## Launch (from hpc-code login node, dispatcher repo root):
@@ -15,7 +15,7 @@ description: embedding-recovery smoke (hierarchical synthetic + multisubject GRU
 tasks:
   - name: recovery-smoke-gru
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration  # current image for the main line
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -40,6 +40,8 @@ tasks:
       - name: WRAPPER_REF
         value: main
       - name: DISPATCHER_REF
+        value: main
+      - name: FORAGING_MODELS_REF
         value: main
     result:
       path: /results

--- a/code/beaker/experiment_scaling.yaml
+++ b/code/beaker/experiment_scaling.yaml
@@ -47,6 +47,6 @@ tasks:
         # per-subject split-example build + load groupby + eval GPU chunking.
         value: 57dcd3a0ba68b2093a02078a3d83e4d12b2facf2
       - name: DISPATCHER_REF
-        value: ai_hub_pck_integration
+        value: main
     result:
       path: /results

--- a/code/beaker/experiment_scaling.yaml
+++ b/code/beaker/experiment_scaling.yaml
@@ -47,8 +47,8 @@ tasks:
         # per-subject split-example build + load groupby + eval GPU chunking.
         value: 57dcd3a0ba68b2093a02078a3d83e4d12b2facf2
       - name: DISPATCHER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: FORAGING_MODELS_REF
-        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e
+        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e  # main
     result:
       path: /results

--- a/code/beaker/experiment_scaling.yaml
+++ b/code/beaker/experiment_scaling.yaml
@@ -14,7 +14,7 @@ description: disRNN scaling — N wandb-agent replicas sharing one sweep
 tasks:
   - name: disrnn-scaling
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration
+      beaker: han-hou/disrnn-wrapper-main-20260712
     # No --count: each agent drains the sweep queue until the grid is
     # exhausted, then exits. With replicas=4 and 8 combos that's ~2 runs/GPU.
     command:
@@ -48,5 +48,7 @@ tasks:
         value: 57dcd3a0ba68b2093a02078a3d83e4d12b2facf2
       - name: DISPATCHER_REF
         value: main
+      - name: FORAGING_MODELS_REF
+        value: b44b0912de8d5307debe9b3b1c570cfc6dad816e
     result:
       path: /results

--- a/code/beaker_client.py
+++ b/code/beaker_client.py
@@ -41,12 +41,21 @@ Mac/HPC/Beaker architecture this fits into.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
+from urllib.parse import quote
 
 import requests
 import yaml
 
 WANDB_GQL_URL = "https://api.wandb.ai/graphql"
+GITHUB_API_URL = "https://api.github.com"
+RUNTIME_REF_REPOSITORIES = {
+    "WRAPPER_REF": "aind-disrnn-wrapper",
+    "DISPATCHER_REF": "aind-disrnn-dispatcher",
+    "FORAGING_MODELS_REF": "aind-dynamic-foraging-models",
+}
+_FULL_GIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
 
 _UPSERT_SWEEP_MUTATION = """
 mutation UpsertSweep(
@@ -81,6 +90,66 @@ mutation UpsertSweep(
     }
 }
 """
+
+
+def resolve_github_ref(repository: str, ref: str) -> str:
+    """Resolve a GitHub branch, tag, or commit to a full commit SHA."""
+    if _FULL_GIT_SHA.fullmatch(ref):
+        return ref.lower()
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if token := os.environ.get("GITHUB_TOKEN"):
+        headers["Authorization"] = f"Bearer {token}"
+    url = (
+        f"{GITHUB_API_URL}/repos/AllenNeuralDynamics/{repository}/commits/"
+        f"{quote(ref, safe='')}"
+    )
+    try:
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError(
+            f"could not resolve AllenNeuralDynamics/{repository}@{ref}: {exc}"
+        ) from exc
+    sha = response.json().get("sha", "")
+    if not _FULL_GIT_SHA.fullmatch(sha):
+        raise RuntimeError(
+            f"GitHub returned an invalid commit for "
+            f"AllenNeuralDynamics/{repository}@{ref}: {sha!r}"
+        )
+    return sha.lower()
+
+
+def pin_runtime_refs(
+    spec: dict, cache: dict[tuple[str, str], str] | None = None
+) -> dict[tuple[str, str], str]:
+    """Replace runtime REF values in every task with full GitHub commit SHAs."""
+    resolved = cache if cache is not None else {}
+    for task in spec.get("tasks", []):
+        env_by_name = {
+            item.get("name"): item
+            for item in task.get("envVars", [])
+            if item.get("name") in RUNTIME_REF_REPOSITORIES
+        }
+        missing = set(RUNTIME_REF_REPOSITORIES) - set(env_by_name)
+        if missing:
+            names = ", ".join(sorted(missing))
+            raise ValueError(
+                f"task {task.get('name', '<unnamed>')!r} is missing runtime refs: {names}"
+            )
+        for name, repository in RUNTIME_REF_REPOSITORIES.items():
+            item = env_by_name[name]
+            ref = item.get("value")
+            if not isinstance(ref, str) or not ref:
+                raise ValueError(
+                    f"task {task.get('name', '<unnamed>')!r} has invalid {name}: {ref!r}"
+                )
+            key = (repository, ref)
+            if key not in resolved:
+                resolved[key] = resolve_github_ref(repository, ref)
+                print(f"[runtime-refs] {name}: {ref} -> {resolved[key]}")
+            item["value"] = resolved[key]
+    return resolved
 
 
 def create_wandb_sweep(sweep_file: str, wandb_api_key: str | None = None) -> str:

--- a/code/launch_beaker.py
+++ b/code/launch_beaker.py
@@ -45,7 +45,7 @@ from launch_beaker_resumable import _seattle_launch_id, _study_variant
 
 # Library-only clients (GraphQL for W&B, beaker-py for Beaker) -- no `wandb`/`beaker`
 # CLI dependency; see code/beaker_client.py docstring for why.
-from beaker_client import create_wandb_sweep, submit_beaker_experiment
+from beaker_client import create_wandb_sweep, pin_runtime_refs, submit_beaker_experiment
 
 REPO_ROOT = Path(__file__).resolve().parent.parent  # the dispatcher capsule root (a git repo)
 RESULTS = Path("/results")
@@ -103,12 +103,15 @@ def _render_experiment(experiment_file: str, sweep_id: str, group: str, meta_env
 
 def submit_experiment(
     experiment_file: str, sweep_id: str, workspace: str,
-    group: str, meta_env: list, output_dir: Path = RESULTS,
+    group: str, meta_env: list, ref_cache: dict,
+    output_dir: Path = RESULTS,
 ) -> str | None:
     """Render <SWEEP_ID> + provenance into the experiment spec and `beaker experiment create`."""
     output_dir.mkdir(parents=True, exist_ok=True)
     rendered = output_dir / "experiment_submitted.yaml"
-    rendered.write_text(yaml.safe_dump(_render_experiment(experiment_file, sweep_id, group, meta_env), sort_keys=False))
+    spec = _render_experiment(experiment_file, sweep_id, group, meta_env)
+    pin_runtime_refs(spec, cache=ref_cache)
+    rendered.write_text(yaml.safe_dump(spec, sort_keys=False))
     print(f"[launch_beaker] submitting {rendered.name} to {workspace}")
     try:
         experiment_id = submit_beaker_experiment(str(rendered), workspace)
@@ -178,6 +181,15 @@ def main() -> None:
     print(f"[launch_beaker] study={study} variant={variant} launch_id={launch_id} "
           f"group={group} config_hash={config_hash}")
 
+    ref_cache: dict[tuple[str, str], str] = {}
+    try:
+        preflight = _render_experiment(
+            args.experiment, "<SWEEP_ID>", group, meta_env
+        )
+        pin_runtime_refs(preflight, cache=ref_cache)
+    except (RuntimeError, ValueError) as exc:
+        sys.exit(f"[launch_beaker] runtime ref resolution failed: {exc}")
+
     sweep_id = create_sweep(args.sweep)
     print(f"[launch_beaker] SWEEP_ID = {sweep_id}")
 
@@ -185,10 +197,15 @@ def main() -> None:
     if args.no_submit:
         rendered = output_dir / "experiment_submitted.yaml"
         output_dir.mkdir(parents=True, exist_ok=True)
-        rendered.write_text(yaml.safe_dump(_render_experiment(args.experiment, sweep_id, group, meta_env), sort_keys=False))
+        spec = _render_experiment(args.experiment, sweep_id, group, meta_env)
+        pin_runtime_refs(spec, cache=ref_cache)
+        rendered.write_text(yaml.safe_dump(spec, sort_keys=False))
         print(f"[launch_beaker] --no-submit set; wrote {rendered} (not submitted)")
     else:
-        experiment_id = submit_experiment(args.experiment, sweep_id, args.workspace, group, meta_env, output_dir)
+        experiment_id = submit_experiment(
+            args.experiment, sweep_id, args.workspace, group, meta_env,
+            ref_cache, output_dir,
+        )
 
     save_record(args.sweep, sweep_id, experiment_id, output_dir)
     print("[launch_beaker] done")

--- a/code/launch_beaker_resumable.py
+++ b/code/launch_beaker_resumable.py
@@ -52,7 +52,7 @@ import yaml
 
 # Library-only Beaker client (beaker-py) -- no `beaker` CLI dependency; see
 # code/beaker_client.py docstring for why.
-from beaker_client import submit_beaker_experiment
+from beaker_client import pin_runtime_refs, submit_beaker_experiment
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 # Where the launch record is written. /results is the Code Ocean capsule path; it does not
@@ -281,6 +281,10 @@ def main() -> None:
 
     output_dir = Path(args.output_dir)
     spec = build_spec(args.sweep, args.experiment, label=args.label, note=args.note)
+    try:
+        pin_runtime_refs(spec)
+    except (RuntimeError, ValueError) as exc:
+        sys.exit(f"[resumable] runtime ref resolution failed: {exc}")
     n_tasks = len(spec["tasks"])
     print(f"[resumable] expanded grid into {n_tasks} tasks")
 

--- a/docs/repo-split-plan.md
+++ b/docs/repo-split-plan.md
@@ -13,8 +13,8 @@ status: proposed
 # Repo-split plan: extract `studies/` into `aind-disrnn-studies`
 
 > **Status:** proposed, not executed. Delegated to a separate agent for execution.
-> Written after the `posthoc-analysis` standard-structure migration (branch
-> `ai_hub_pck_integration`, ending at commit `122abfd`).
+> Written after the `posthoc-analysis` standard-structure migration on the
+> integration line, ending at commit `122abfd` and later merged to `main`.
 
 ## TL;DR
 
@@ -106,10 +106,9 @@ whether or not analysis ever becomes its own repo.
 
 ## Prerequisites (do these before executing)
 
-1. **All in-flight PRs against dispatcher must be merged first.** As of writing,
-   branch `ai_hub_pck_integration` is 35 commits ahead of
-   `origin/ai_hub_pck_integration` (unpushed). Any commits not on `main`
-   at split time will be silently dropped from the studies extract.
+1. **All in-flight PRs against dispatcher must be merged first.** The integration
+   line is now merged to `main`; any commits not on `main` at split time will be
+   silently dropped from the studies extract.
    -> verify: `git log origin/main..HEAD -- studies/` prints nothing.
 2. **Snapshot AGENTS.md rev**, since content flows across both repos.
    -> verify: record `git log -1 --format=%H AGENTS.md` in the studies-repo

--- a/studies/02-gru-scaling-law-ignore/variants/nxd-3way/experiment.yaml
+++ b/studies/02-gru-scaling-law-ignore/variants/nxd-3way/experiment.yaml
@@ -9,7 +9,7 @@ description: ignore-trials nxd-3way template (one autoResume task per grid point
 tasks:
   - name: ignore-nxd-3way-template
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -26,8 +26,10 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: 4530d0439f929bb5809ed8bb1ee81d8192b3ff6c   # feat/ignore-engagement-metrics HEAD: 3-way + engage/ignore metrics + all bug fixes
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: feat/ignore-trials-scaling                   # study configs (ignore_policy=include, sweep params)
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
     result:
       path: /results

--- a/studies/02-gru-scaling-law-ignore/variants/validation-2way-vs-3way/experiment.yaml
+++ b/studies/02-gru-scaling-law-ignore/variants/validation-2way-vs-3way/experiment.yaml
@@ -1,16 +1,13 @@
 # Task template for variant validation-2way-vs-3way (consumed by launch_beaker_resumable.py).
 # Smoke/first-look: 2 grid tasks (ignore_policy = exclude | include). g6e L40S, one GPU bundle
-# (90GiB / 12 CPU); H128 fits easily on a 48GB L40S. WRAPPER_REF 4f29680 carries the output_size=3
-# (3-way) support + the offline-heldout / few-shot knobs used by data-scaling-law's g6e runs.
-# DISPATCHER_REF study/data-scaling-law supplies code/config (mice_snapshot_scaling has an
-# overridable ignore_policy field) — the ONLY change vs data-scaling-law is the swept
-# data.ignore_policy override injected by the sweep.
+# (90GiB / 12 CPU); H128 fits easily on a 48GB L40S. Runtime refs stay readable as
+# `main`; the launcher resolves them to immutable SHAs before submission.
 version: v2
 description: ignore-trials validation template — 2-way vs 3-way smoke (one autoResume task per grid point)
 tasks:
   - name: ignore-validation-template
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -27,8 +24,10 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: 4f296807f4ea06f9a58afa4eeb0553c220db4726   # output_size=3 (3-way) + offline-heldout/few-shot knobs
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: study/data-scaling-law                       # code/config source (overridable ignore_policy)
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
     result:
       path: /results

--- a/studies/03-disrnn-beta-scan/README.md
+++ b/studies/03-disrnn-beta-scan/README.md
@@ -105,7 +105,8 @@ two figures, then rewrites the report blocks. Reports:
   were computed offline from checkpoints and pushed to W&B.
 
 ## Provenance
-- **Dispatcher branch:** `pr/beta-scan-clean` (→ PR #39, base `ai_hub_pck_integration`).
+- **Dispatcher branch:** `pr/beta-scan-clean` (PR #39, originally based on the
+  integration line; now contained in `main` through PR #53).
   **Wrapper:** metrics-producing commit pinned in [`environment.lock`](environment.lock)
   and stamped into `beta_scan_summary.json` as `_meta.wrapper_git_sha`.
 - **Beaker image:** `han-hou/disrnn-wrapper-pck-integration-20260630` (entrypoint

--- a/studies/03-disrnn-beta-scan/variants/smoke/experiment.yaml
+++ b/studies/03-disrnn-beta-scan/variants/smoke/experiment.yaml
@@ -7,9 +7,8 @@
 # L40S, so route to g6e (one 90GiB / 12-CPU bundle), NOT octo-hub-onprem-h200. Keeping it
 # off H200 also avoids contending with the running ignore-trials nxd-3way grid there.
 #
-# WRAPPER_REF is pinned to the bottleneck-sparsity-logging commit so each run logs the
-# real-time bottlenecks/* scalars (incl. the isolated update_net_latent channel). The
-# entrypoint git-pulls this at container startup — no image rebuild needed (code-only edit).
+# Runtime refs stay readable as `main`; the launcher resolves them to immutable SHAs
+# before submission. The entrypoint checks out those SHAs at container startup.
 version: v2
 description: >
   beta-scan updnet-ratio-100mice — 48-task grid over update_net_latent_penalty_multiplier
@@ -17,7 +16,7 @@ description: >
 tasks:
   - name: beta-scan-updnet-ratio-template
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -34,9 +33,11 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: 87d93f8c989e2059b67c1e87c137f799103ada77   # + length bucketing + extend-later restore
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: feat/beta-scan                              # this study's code/config source
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
       # (online by default; safeguard auto-falls-back to offline on a flaky init)
     result:
       path: /results

--- a/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice-mult10-oomretry/experiment.yaml
+++ b/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice-mult10-oomretry/experiment.yaml
@@ -7,10 +7,8 @@
 # L40S, so route to g6e (one 90GiB / 12-CPU bundle), NOT octo-hub-onprem-h200. Keeping it
 # off H200 also avoids contending with the running ignore-trials nxd-3way grid there.
 #
-# WRAPPER_REF is pinned to the bottleneck-sparsity-logging branch commit that carries:
-# real-time bottlenecks/* scalars (incl. the isolated update_net_latent channel), disRNN
-# length-bucketed batching, and the extend-later checkpoint-restore path. The entrypoint
-# git-pulls this at container startup — no image rebuild needed (code-only edits).
+# Runtime refs stay readable as `main`; the launcher resolves them to immutable SHAs
+# before submission. The entrypoint checks out those SHAs at container startup.
 version: v2
 description: >
   beta-scan updnet-ratio-100mice — 48-task grid over update_net_latent_penalty_multiplier
@@ -18,7 +16,7 @@ description: >
 tasks:
   - name: beta-scan-updnet-ratio-template
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -35,9 +33,11 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: 87d93f8c989e2059b67c1e87c137f799103ada77   # + length bucketing + extend-later restore
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: feat/beta-scan                              # this study's code/config source
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
       # (online by default; safeguard auto-falls-back to offline on a flaky init)
     result:
       path: /results

--- a/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice-mult10-supp/experiment.yaml
+++ b/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice-mult10-supp/experiment.yaml
@@ -7,10 +7,8 @@
 # L40S, so route to g6e (one 90GiB / 12-CPU bundle), NOT octo-hub-onprem-h200. Keeping it
 # off H200 also avoids contending with the running ignore-trials nxd-3way grid there.
 #
-# WRAPPER_REF is pinned to the bottleneck-sparsity-logging branch commit that carries:
-# real-time bottlenecks/* scalars (incl. the isolated update_net_latent channel), disRNN
-# length-bucketed batching, and the extend-later checkpoint-restore path. The entrypoint
-# git-pulls this at container startup — no image rebuild needed (code-only edits).
+# Runtime refs stay readable as `main`; the launcher resolves them to immutable SHAs
+# before submission. The entrypoint checks out those SHAs at container startup.
 version: v2
 description: >
   beta-scan updnet-ratio-100mice — 48-task grid over update_net_latent_penalty_multiplier
@@ -18,7 +16,7 @@ description: >
 tasks:
   - name: beta-scan-updnet-ratio-template
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -36,9 +34,11 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: 87d93f8c989e2059b67c1e87c137f799103ada77   # + length bucketing + extend-later restore
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: feat/beta-scan                              # this study's code/config source
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
       # (online by default; safeguard auto-falls-back to offline on a flaky init)
     result:
       path: /results

--- a/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice-ruleplot-3dcb9217/experiment.yaml
+++ b/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice-ruleplot-3dcb9217/experiment.yaml
@@ -7,10 +7,8 @@
 # L40S, so route to g6e (one 90GiB / 12-CPU bundle), NOT octo-hub-onprem-h200. Keeping it
 # off H200 also avoids contending with the running ignore-trials nxd-3way grid there.
 #
-# WRAPPER_REF is pinned to the bottleneck-sparsity-logging branch commit that carries:
-# real-time bottlenecks/* scalars (incl. the isolated update_net_latent channel), disRNN
-# length-bucketed batching, and the extend-later checkpoint-restore path. The entrypoint
-# git-pulls this at container startup — no image rebuild needed (code-only edits).
+# Runtime refs stay readable as `main`; the launcher resolves them to immutable SHAs
+# before submission. The entrypoint checks out those SHAs at container startup.
 version: v2
 description: >
   beta-scan updnet-ratio-100mice — 48-task grid over update_net_latent_penalty_multiplier
@@ -18,7 +16,7 @@ description: >
 tasks:
   - name: beta-scan-updnet-ratio-template
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -35,9 +33,11 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: 87d93f8c989e2059b67c1e87c137f799103ada77   # + length bucketing + extend-later restore
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: feat/beta-scan                              # this study's code/config source
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
       # (online by default; safeguard auto-falls-back to offline on a flaky init)
     result:
       path: /results

--- a/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice-ruleplot-45646c46/experiment.yaml
+++ b/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice-ruleplot-45646c46/experiment.yaml
@@ -7,10 +7,8 @@
 # L40S, so route to g6e (one 90GiB / 12-CPU bundle), NOT octo-hub-onprem-h200. Keeping it
 # off H200 also avoids contending with the running ignore-trials nxd-3way grid there.
 #
-# WRAPPER_REF is pinned to the bottleneck-sparsity-logging branch commit that carries:
-# real-time bottlenecks/* scalars (incl. the isolated update_net_latent channel), disRNN
-# length-bucketed batching, and the extend-later checkpoint-restore path. The entrypoint
-# git-pulls this at container startup — no image rebuild needed (code-only edits).
+# Runtime refs stay readable as `main`; the launcher resolves them to immutable SHAs
+# before submission. The entrypoint checks out those SHAs at container startup.
 version: v2
 description: >
   beta-scan updnet-ratio-100mice — 48-task grid over update_net_latent_penalty_multiplier
@@ -18,7 +16,7 @@ description: >
 tasks:
   - name: beta-scan-updnet-ratio-template
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -35,9 +33,11 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: 87d93f8c989e2059b67c1e87c137f799103ada77   # + length bucketing + extend-later restore
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: feat/beta-scan                              # this study's code/config source
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
       # (online by default; safeguard auto-falls-back to offline on a flaky init)
     result:
       path: /results

--- a/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice/experiment.yaml
+++ b/studies/03-disrnn-beta-scan/variants/updnet-ratio-100mice/experiment.yaml
@@ -7,10 +7,8 @@
 # L40S, so route to g6e (one 90GiB / 12-CPU bundle), NOT octo-hub-onprem-h200. Keeping it
 # off H200 also avoids contending with the running ignore-trials nxd-3way grid there.
 #
-# WRAPPER_REF is pinned to the bottleneck-sparsity-logging branch commit that carries:
-# real-time bottlenecks/* scalars (incl. the isolated update_net_latent channel), disRNN
-# length-bucketed batching, and the extend-later checkpoint-restore path. The entrypoint
-# git-pulls this at container startup — no image rebuild needed (code-only edits).
+# Runtime refs stay readable as `main`; the launcher resolves them to immutable SHAs
+# before submission. The entrypoint checks out those SHAs at container startup.
 version: v2
 description: >
   beta-scan updnet-ratio-100mice — 48-task grid over update_net_latent_penalty_multiplier
@@ -18,7 +16,7 @@ description: >
 tasks:
   - name: beta-scan-updnet-ratio-template
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration-20260630
+      beaker: han-hou/disrnn-wrapper-main-20260712
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh
@@ -35,9 +33,11 @@ tasks:
       - name: WANDB_API_KEY
         secret: han-wandb-api-key
       - name: WRAPPER_REF
-        value: 87d93f8c989e2059b67c1e87c137f799103ada77   # + length bucketing + extend-later restore
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: feat/beta-scan                              # this study's code/config source
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
       # (online by default; safeguard auto-falls-back to offline on a flaky init)
     result:
       path: /results

--- a/studies/04-gru-vs-disrnn-embedding-recovery/variants/gru-stage1/experiment.yaml
+++ b/studies/04-gru-vs-disrnn-embedding-recovery/variants/gru-stage1/experiment.yaml
@@ -35,8 +35,10 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
       - name: DISPATCHER_REF
-        value: main
+        value: main  # readable source ref; launcher submits the resolved SHA
+      - name: FORAGING_MODELS_REF
+        value: main  # readable source ref; launcher submits the resolved SHA
     result:
       path: /results

--- a/studies/04-gru-vs-disrnn-embedding-recovery/variants/gru-stage1/experiment.yaml
+++ b/studies/04-gru-vs-disrnn-embedding-recovery/variants/gru-stage1/experiment.yaml
@@ -1,7 +1,7 @@
 ## Beaker spec — embedding-recovery / gru-stage1 on gcp-h100.
 ## The launcher renders <SWEEP_ID> and injects provenance env at submit.
 ## Entrypoint refreshes both repos to the refs below at container startup, so
-## pushing feat/embedding-recovery is enough (no image rebuild for code/config).
+## code/config changes need no image rebuild.
 ##
 ## To spread the 36-point grid across GPUs, launch with --count > 1 agents
 ## (each wandb agent pulls the next grid point). See beaker-launch skill.
@@ -35,8 +35,8 @@ tasks:
       - name: DISRNN_OUTPUT_DIR
         value: /results
       - name: WRAPPER_REF
-        value: feat/embedding-recovery
+        value: main
       - name: DISPATCHER_REF
-        value: feat/embedding-recovery
+        value: main
     result:
       path: /results

--- a/studies/04-gru-vs-disrnn-embedding-recovery/variants/gru-stage1/experiment.yaml
+++ b/studies/04-gru-vs-disrnn-embedding-recovery/variants/gru-stage1/experiment.yaml
@@ -1,6 +1,6 @@
 ## Beaker spec — embedding-recovery / gru-stage1 on gcp-h100.
 ## The launcher renders <SWEEP_ID> and injects provenance env at submit.
-## Entrypoint refreshes both repos to the refs below at container startup, so
+## Entrypoint refreshes all three repos to the refs below at container startup, so
 ## code/config changes need no image rebuild.
 ##
 ## To spread the 36-point grid across GPUs, launch with --count > 1 agents
@@ -12,7 +12,7 @@ description: embedding-recovery Stage-1 GRU subject-embedding recovery grid (gcp
 tasks:
   - name: recovery-gru-stage1
     image:
-      beaker: han-hou/disrnn-wrapper-pck-integration  # current image; verify with `beaker image list`
+      beaker: han-hou/disrnn-wrapper-main-20260712  # current image; verify with `beaker image list`
     command:
       - bash
       - /workspace/aind-disrnn-wrapper/beaker/entrypoint.sh


### PR DESCRIPTION
## Summary
- replace stale integration-branch references with `main` or immutable merged SHAs
- point reusable Beaker templates and guidance at `han-hou/disrnn-wrapper-main-20260712`
- expose `FORAGING_MODELS_REF` alongside wrapper and dispatcher refs
- resolve branch/tag values for all three runtime repos before W&B sweep creation or Beaker submission
- save and submit rendered experiment YAML containing only full 40-character SHAs
- preserve readable source refs in inline comments and preserve historical launch records unchanged

## Dependency
- AllenNeuralDynamics/aind-disrnn-wrapper#54 is merged

## Validation
- parsed every modified Beaker experiment YAML
- Python syntax compilation and `git diff --check`
- mocked native and 8-task resumable launcher integration checks
- live read-only GitHub resolution of all three `main` refs
- verified missing runtime refs fail before external state creation
- refreshed and verified the installed Codex skill copies