### PR TITLE
docs(hpc): forbid ALL Python on the login node, not just 'heavy' work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,22 @@ These guidelines are working when diffs contain fewer unnecessary changes, solut
 
 ## 5. HPC Execution Safety
 
-Never run computation-intensive work on the login node (where the agent runs).
+**Never run *any* Python on the login node (where the agent runs) — no exceptions.**
+This covers training, sweeps, analysis, synthetic data generation, and "quick" smoke
+tests or single-worker checks, whether run interactively or shipped ad-hoc via
+`call_command`/SSH.
 
-- Always use `srun` or `sbatch` for heavy workloads.
-- This includes training jobs, sweeps, and tests.
+- All workload Python goes through `srun`/`sbatch`/`salloc` onto a compute node.
+- The **only** Python permitted on the login node is a *submit-only launcher*
+  (`launch_hpc.py`, `launch_beaker*.py`, `check_gpu_availability.py`) that creates a
+  W&B sweep, submits jobs, or probes capacity and returns — it never imports the
+  wrapper data loader, model, or training code, and never starts a `multiprocessing`
+  Pool.
+- Why: even a "small" login-node job shares the node with every other user. A bug in
+  one — e.g. an unguarded `multiprocessing` spawn-Pool that re-imports its own script
+  as `__main__` and recursively forks without bound — can trigger a runaway
+  process-spawn cascade that hammers the whole node. (Real incident: an ad-hoc
+  data-gen smoke test left a 260 MB log with 65k+ process-spawn errors on hpc-code.)
 
 ## 6. Semantic Commit Messages
 

--- a/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
+++ b/aind-behavior-foundation-model-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aind-behavior-foundation-model-skills",
   "description": "Agent Skills for the AIND behavior foundation model stack: codebase orientation for the disRNN dispatcher/wrapper repos, launching jobs on Beaker (AI Hub) and Allen on-prem SLURM HPC, study/variant organization, and post-hoc analysis reporting conventions.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "Han Hou",
     "email": "houhan@gmail.com"

--- a/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
@@ -10,8 +10,15 @@ README wins.**
 
 ## Hard rules first
 
-1. **Never run computation on the login node** (where you run). Everything heavy goes
-   through `sbatch`/`srun` — including smoke tests.
+1. **Never run *any* Python on the login node** (where you run) — no exceptions.
+   Training, sweeps, analysis, synthetic data generation, and "quick" smoke tests or
+   single-worker checks all go through `sbatch`/`srun`/`salloc` onto a compute node,
+   whether run interactively or shipped ad-hoc via `call_command`/SSH. The **only**
+   Python allowed on the login node is a *submit-only launcher* (`launch_hpc.py`,
+   `launch_beaker*.py`, `check_gpu_availability.py`) — it creates a sweep / submits /
+   probes capacity and returns, never importing wrapper loader/model/training code or
+   starting a `multiprocessing` Pool. (An unguarded spawn-Pool on the login node once
+   recursively forked into a 260 MB / 65k-error process cascade.)
 2. Invoke the launcher from the `disrnn-cpu` conda env
    (`/allen/aind/scratch/han.hou/miniforge3/envs/disrnn-cpu`). The SLURM script
    activates `disrnn-cpu` or `disrnn-gpu` on the compute node per `--mode`.


### PR DESCRIPTION
## What

Make the HPC login-node rule **absolute**: *never run any Python on the `hpc-code` login node* — no exceptions. Previously both docs said "never run **computation-intensive** / **heavy** work," which left room for "quick" smoke tests and single-worker checks. This tightens the wording in:

- **`AGENTS.md` §5 — HPC Execution Safety**
- **`hpc-launch` skill — Hard rule #1**

The one carve-out is explicit: *submit-only launchers* (`launch_hpc.py`, `launch_beaker*.py`, `check_gpu_availability.py`) may still run on the login node — they create a sweep / submit / probe capacity and return, and never import the wrapper loader/model/training code or start a `multiprocessing` Pool.

## Why

A real incident: an ad-hoc Stage-4b data-generation smoke test (`/tmp/s4bl.py`) called a `spawn`-context `multiprocessing.Pool` loader **without an `if __name__ == '__main__':` guard**. Under `spawn`, each worker re-imported the script as `__main__`, re-ran the loader, and tried to open its own Pool — an unbounded recursive process-spawn cascade on the shared login node. It left a **260 MB log with 65,000+ `start a new process` RuntimeErrors**. Even a "small" login-node job shares the node with every other user, so the safe rule is simply: no workload Python on the login node, ever.

## Changes
- `AGENTS.md` §5: absolute ban + submit-only-launcher carve-out + incident rationale
- `hpc-launch/SKILL.md` hard rule #1: same, in skill voice
- `plugin.json`: `0.6.0` → `0.6.1` (skill content change)

No code changes; docs/skill only.