### PR TITLE
feat(disrnn-config): couple the three subject penalties to subject_penalty

### DIFF
--- a/code/config/model/disrnn.yaml
+++ b/code/config/model/disrnn.yaml
@@ -31,9 +31,17 @@ penalties:
   update_net_obs_penalty: ${.beta}
   update_net_latent_penalty_multiplier: 1.0
   update_net_latent_penalty: ${.beta}
+  # The subject pathway has THREE bottlenecks (the global subject bottleneck, and the
+  # subject channels into the update net and the choice net). They are coupled to
+  # `subject_penalty` rather than to `beta` directly, so overriding `subject_penalty`
+  # relaxes the whole subject pathway with one knob. Pinning the downstream two to
+  # `beta` instead would leave them clamped when `subject_penalty` is swept, so the
+  # subject embedding would stay bottlenecked downstream and a capacity experiment
+  # would silently return a false negative. Default is unchanged (`subject_penalty`
+  # resolves to `beta`), so this is backward-compatible with studies 01-05.
   subject_penalty: ${.beta}
-  update_net_subject_penalty: ${.beta}
-  choice_net_subject_penalty: ${.beta}
+  update_net_subject_penalty: ${.subject_penalty}
+  choice_net_subject_penalty: ${.subject_penalty}
 
 distillation:
   enabled: false


### PR DESCRIPTION
## The problem

The disRNN's subject pathway has **three** bottlenecks, and all three independently resolved to `beta`:

```yaml
subject_penalty: ${.beta}
update_net_subject_penalty: ${.beta}    # the subject channel into the update net
choice_net_subject_penalty: ${.beta}    # the subject channel into the choice net
```

So sweeping `subject_penalty` alone relaxes the front door while leaving the other two **clamped at `beta`** — the subject embedding stays bottlenecked downstream. A subject-capacity experiment run this way returns a **false negative**: hand the model a 64-dim embedding, watch the downstream gates shut it anyway, and wrongly conclude per-subject capacity doesn't help.

## The change

Point the two downstream penalties at `${.subject_penalty}` rather than `${.beta}`, so one knob relaxes the whole subject pathway.

**Backward-compatible.** `subject_penalty` still defaults to `${.beta}`, so with no override every penalty resolves exactly as before — studies 01–05 are unaffected. Verified by resolving the config under a Hydra-like root:

| override | beta | subject (3) | other (4) |
|---|---|---|---|
| *(default)* | 0.001 | `[0.001, 0.001, 0.001]` | `[0.001] × 4` |
| `subject_penalty=1e-4` | 0.001 | `[1e-4, 1e-4, 1e-4]` | `[0.001] × 4` |
| `subject_penalty=0` | 0.001 | `[0, 0, 0]` | `[0.001] × 4` |
| `beta=3e-4` | 3e-4 | `[3e-4, 3e-4, 3e-4]` | `[3e-4] × 4` |

The subject knob moves exactly the subject penalties and nothing else; `beta` still moves everything.

## Why now

Study 05 (`05-disrnn-scaling-law`) finds that as the cohort grows, the disRNN **abandons per-mouse personalization**:

| D | 10 | 30 | 100 | 300 |
|---|---|---|---|---|
| `update←subject` openness Σ(1−σ) | 0.850 | 0.984 | 0.780 | **0.640** |
| `choice←subject` openness | 0.002 | 0.001 | 0.001 | **0.001** (shut) |
| `update←latent` (interaction) | 0.161 | 0.481 | 0.774 | **0.922** |

The choice net never uses subject identity at all, `update←subject` *closes* with D, and the shared interaction/recurrent gates open. Meanwhile the disRNN sits **~0.010 below the GRU** in held-out likelihood at *every* D, and is only at parity with a per-mouse classical RL baseline.

That points at **per-subject capacity — not the interaction bottleneck — as what caps held-out transfer**. This change makes that testable: `subject_penalty=0` is the **GRU limit of the subject pathway** (the GRU's embedding has no bottleneck), holding everything else disRNN, which turns the hypothesis into a causal test.

Consumed by the forthcoming `05-disrnn-scaling-law/variants/subject-capacity` grid: `subject_embedding_size ∈ {4,16,64}` × `subject_penalty ∈ {β, β/10, 0}` at D=100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127mCUQkekGsRtNEQPXRSw3