### PR TITLE
feat(provenance): schema + reconciler for post-launch interventions

### DIFF
--- a/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/beaker-launch/SKILL.md
@@ -166,6 +166,11 @@ the fan-out. Routine repeats of known-good launches: fan out directly.
   label "verified:" vs "likely, unconfirmed:" (AGENTS.md §11).
 - After the launch settles, write `launch_record_<label>/results.md`
   (see posthoc-reporting skill).
+- **Any post-launch intervention — resubmit, rescue, probe, tier change — must write a
+  launch record**, or it is lost: the launchers only record the *first* launch. Use
+  `studies/util/launch_record.py::write_intervention(..., platform="beaker",
+  job_refs=[{"type": "beaker_experiment", "id": exp.id}])`; schema and the wrap-up
+  reconciler (`validate_provenance.py`) live in the `study-conventions` skill.
 
 ## References (read on demand)
 

--- a/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
@@ -118,6 +118,32 @@ detail: wrapper `../aind-disrnn-wrapper/code/TRAINING.md` §1.5):
   GCS + W&B) and the HPC original `code/resume_heldout.py` (`--model-dir <dir> --wandb-run-id
   <id>`, run on a compute node that can read the checkpoint tree + reach W&B).
 
+## Recording an intervention (resubmit / rescue / probe / backfill)
+
+`launch_hpc.py` writes **no launch-record JSON** — unlike the Beaker launchers, it leaves no
+file behind describing what was submitted. So anything you do after the initial sweep
+(resubmitting dead array tasks, rescuing a wedged job, a diagnostic rerun, recovering a metric
+post-hoc) must be recorded by hand or it is lost:
+
+```python
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "util"))
+from launch_record import write_intervention
+
+write_intervention(
+    path=variant / "launch_record" / "hpc_<label>.json",
+    kind="resubmit", platform="hpc",
+    wandb_group="<variant>@<launch_id>",
+    study_root=STUDY,
+    job_refs=[{"type": "wandb_sweep", "id": sweep_id},          # PREFER this
+              {"type": "slurm_array_job", "id": array_job_id}],  # ages out of sacct
+    trigger={"symptom": "array tasks 3-7 died", "cause": "node OOM"},
+)
+```
+
+**Record the W&B sweep id, not just the SLURM id.** SLURM job ids are recycled and drop out of
+`sacct` history within days, so a sweep id is the only handle that still resolves later. Schema
+and the wrap-up validator: the `study-conventions` skill.
+
 ## Monitoring
 
 ```bash

--- a/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/hpc-launch/SKILL.md
@@ -126,9 +126,11 @@ file behind describing what was submitted. So anything you do after the initial 
 post-hoc) must be recorded by hand or it is lost:
 
 ```python
+import sys
+from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "util"))
 from launch_record import write_intervention
-
 write_intervention(
     path=variant / "launch_record" / "hpc_<label>.json",
     kind="resubmit", platform="hpc",

--- a/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
@@ -60,9 +60,11 @@ metric values documented only in prose. Interventions are the surprising events 
 provenance exists for — so they get a fixed schema:
 
 ```python
+import sys
+from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "util"))
 from launch_record import write_intervention
-
 write_intervention(
     path=variant / "launch_record" / "<backend>_<label>.json",
     kind="rescue",                    # resubmit|rescue|probe|tier-change|backfill|extend

--- a/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
+++ b/aind-behavior-foundation-model-skills/skills/study-conventions/SKILL.md
@@ -51,6 +51,55 @@ in `AGENTS.md` §8).
   and `launch_beaker.py`) implement the portable launch metadata identically;
   the wrapper records the resolved source commits.
 
+## Interventions after the first launch (resubmit / rescue / probe / tier change / backfill)
+
+The launchers record the **first** launch. Everything afterwards used to be hand-rolled, and
+that is precisely where provenance was lost: study 06 accumulated five follow-up actions with
+five different ad-hoc JSON shapes, **none carrying a timestamp**, plus 6 post-hoc-recovered
+metric values documented only in prose. Interventions are the surprising events — the ones
+provenance exists for — so they get a fixed schema:
+
+```python
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "util"))
+from launch_record import write_intervention
+
+write_intervention(
+    path=variant / "launch_record" / "<backend>_<label>.json",
+    kind="rescue",                    # resubmit|rescue|probe|tier-change|backfill|extend
+    platform="beaker",                # beaker | hpc | none (none == submits nothing)
+    wandb_group="<variant>@<launch_id>",   # the join key the validator reconciles on
+    study_root=STUDY,
+    job_refs=[{"type": "beaker_experiment", "id": exp.id}],   # see backend table below
+    supersedes=["<older experiment/sweep id>"],
+    trigger={"symptom": ..., "cause": ..., "evidence": {...}},   # symptom+cause REQUIRED
+    tasks=[{"orig_task": ..., "new_task": ..., "orig_wandb_run": ..., "new_wandb_run": ...}],
+    deviations={"fresh_run_ids": True, "renamed_tasks": True},
+    cost={"progress_discarded_steps": {...}},
+)
+```
+
+**Works for both backends** — a study can use both (AGENTS.md §13: GPU → Beaker, CPU → HPC
+SLURM). They differ only in what identifies a submitted unit:
+
+| platform | `job_refs` entry | note |
+|---|---|---|
+| `beaker` | `{"type": "beaker_experiment", "id": "01K…"}` | |
+| `hpc` | `{"type": "wandb_sweep", "id": "…"}` | **prefer this** — durable |
+| `hpc` | `{"type": "slurm_array_job" \| "slurm_job", "id": "…"}` | recycled, ages out of `sacct` |
+| `none` | *(omit)* | only for `kind="backfill"` |
+
+`launch_hpc.py` currently writes **no** launch record at all, so an HPC intervention must call
+this helper by hand until that launcher is taught to do it.
+
+It wraps `_meta.build_meta()`, so timestamp + dispatcher/wrapper SHAs come for free, and it
+**refuses** a record with no `trigger.cause`, an unknown platform/ref type, or a work-submitting
+kind with no `job_refs`.
+
+Record the **`deviations`** honestly — every study-06 intervention made a deliberate choice
+(fresh vs reused W&B run ids, renamed tasks, changed priority tier) for a real reason. Reused
+run ids are only safe when the old run logged **nothing**; a from-scratch rerun replays step 0
+while W&B's counter does not rewind.
+
 ## Checklist for a new variant launch
 
 1. Create `studies/<study>/variants/<variant>/` with `sweep.yaml` + `experiment.yaml`
@@ -63,6 +112,18 @@ in `AGENTS.md` §8).
 5. Add a row to the study README's Variants index.
 6. After the group settles, write `launch_record_<label>/results.md`
    (contract in the posthoc-reporting skill).
+7. **Reconcile provenance before calling the variant done:**
+
+   ```bash
+   python studies/util/validate_provenance.py studies/<study> --variant <variant> \
+          --beaker --wandb --strict
+   ```
+
+   Cross-checks three sources that otherwise drift silently: the launch records, the live
+   backends (Beaker experiments / W&B sweeps) targeting the group, and any post-hoc-recovered
+   values flagged in `grid.csv`. Advisory by default; `--strict` exits 1 on findings — use
+   that at wrap-up. Checks 1–2 are offline (no credentials needed); `--beaker` / `--wandb`
+   add the live reconciliation.
 
 ## References (read on demand)
 

--- a/studies/util/launch_record.py
+++ b/studies/util/launch_record.py
@@ -158,14 +158,33 @@ def write_intervention(
             raise ValueError(f"job_ref {r!r} has unknown type; expected one of {REF_TYPES}")
         if not r.get("id"):
             raise ValueError(f"job_ref {r!r} has no id")
-    if kind != "backfill" and not job_refs:
-        raise ValueError(
-            f"kind={kind!r} submits work, so job_refs must be non-empty "
-            '(beaker: [{"type":"beaker_experiment","id":...}]; '
-            'hpc: [{"type":"wandb_sweep","id":...}])'
-        )
-    if kind == "backfill" and platform != "none":
-        raise ValueError('kind="backfill" submits nothing, so platform must be "none"')
+
+    if kind == "backfill":
+        if platform != "none":
+            raise ValueError('kind="backfill" submits nothing, so platform must be "none"')
+        if job_refs:
+            raise ValueError('kind="backfill" submits nothing, so job_refs must be empty')
+    else:
+        if platform == "none":
+            raise ValueError('platform="none" is only valid for kind="backfill"')
+        if not job_refs:
+            raise ValueError(
+                f"kind={kind!r} submits work, so job_refs must be non-empty "
+                '(beaker: [{"type":"beaker_experiment","id":...}]; '
+                'hpc: [{"type":"wandb_sweep","id":...}])'
+            )
+
+    allowed_ref_types = {
+        "beaker": {"beaker_experiment"},
+        "hpc": {"wandb_sweep", "slurm_array_job", "slurm_job"},
+    }
+    allowed = allowed_ref_types.get(platform)
+    if allowed is not None:
+        for r in job_refs:
+            if r.get("type") not in allowed:
+                raise ValueError(
+                    f"job_ref {r!r} not valid for platform {platform!r}; expected type in {sorted(allowed)}"
+                )
 
     record = {
         "_meta": build_meta(produced_by, [wandb_group], study_root=study_root),

--- a/studies/util/launch_record.py
+++ b/studies/util/launch_record.py
@@ -1,0 +1,237 @@
+"""Schema + writer for INTERVENTION launch records (all studies).
+
+WHY THIS EXISTS. A study's *first* launch is well instrumented: the launchers write
+`launch_record/beaker_resumable.json` with a fixed schema and inject the `meta.*` block.
+Everything that happens *afterwards* — resubmitting tasks killed by a bad node, rescuing
+wedged tasks, probing a failure, changing priority tier, backfilling a lost metric — has
+historically been done with a bespoke script that invented its own JSON shape.
+
+Study 06 is the worked example of the cost. Its five launch records looked like this:
+
+    beaker_resumable.json  (launcher)  {chunk_size, mode, n_chunks, n_tasks, parts}
+    beaker_resubmit20.json (by hand)   {bad_node, parts, reason}
+    beaker_nanretry1.json  (by hand)   {experiment_id, purpose, tasks}
+    beaker_rescue1.json    (by hand)   {bad_node, bad_node_hostname, experiment_id,
+                                        progress_discarded, purpose, tasks}
+    beaker_tier1.json      (by hand)   {experiment_id, purpose, superseded_experiment,
+                                        tasks, thrash_evidence}
+
+No two alike, **none carrying a timestamp**, none using `_meta`. Interventions are exactly
+the surprising events provenance exists for, and they were the least well recorded. Prose in
+notes.md filled the gap, but prose is not queryable and drifts from reality.
+
+This module fixes the shape, not the prose. `write_intervention()` wraps the existing
+`_meta.build_meta()` so every record gets a Seattle-time timestamp and both git SHAs for free.
+
+    from launch_record import write_intervention
+
+    write_intervention(
+        path=variant / "launch_record" / "beaker_rescue1.json",
+        kind="rescue",
+        platform="beaker",
+        wandb_group="mult-d-grid@20260718-151409",
+        job_refs=[{"type": "beaker_experiment", "id": "01KYXNJYA7KEY47JXWJGEG4M3Y"}],
+        study_root=STUDY,
+        supersedes=["01KYB43A78GH0X95K1W70EFNSZ"],
+        trigger={"symptom": "3 tasks pending 5 days",
+                 "cause": "node aidc-h200-prd2 image-pull failure",
+                 "evidence": {"node": "01KPVKJYXNWNJCH7ZFK0TBXPW5"}},
+        tasks=[{"orig_task": "...-060", "new_task": "rescue1-060",
+                "orig_wandb_run": "...", "new_wandb_run": "..."}],
+        deviations={"fresh_run_ids": True, "renamed_tasks": True},
+        cost={"progress_discarded_steps": {"060": 76120}},
+    )
+
+BEAKER *AND* HPC. The two backends are handled by one schema because a study can and does
+use both (AGENTS.md section 13: GPU jobs to Beaker, CPU jobs to HPC SLURM, one repo driving
+both). They differ only in what identifies a submitted unit, which is why `job_refs` is a
+list of typed refs rather than a Beaker-shaped `experiment_ids`:
+
+    beaker  ->  {"type": "beaker_experiment",  "id": "01K..."}
+    hpc     ->  {"type": "wandb_sweep",        "id": "abc123"}     # the durable handle
+                {"type": "slurm_array_job",    "id": "12345"}      # ages out of sacct
+                {"type": "slurm_job",          "id": "12345_7"}
+
+For HPC prefer the **W&B sweep id**: SLURM job ids are recycled and drop out of `sacct`
+history, so a sweep id is the only ref that stays resolvable months later. (`launch_hpc.py`
+currently writes no launch record at all — an HPC intervention must call this helper by hand
+until that launcher is taught to do it.)
+
+Times are Seattle per AGENTS.md section 7.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from _meta import build_meta
+
+# Kinds of post-launch intervention. Keep this list short and meaningful: it is what makes
+# records queryable ("show me every rescue across all studies"). Add a kind only when an
+# existing one genuinely does not describe the action.
+KINDS = (
+    "resubmit",      # re-run tasks that never produced usable data (bad node, lost image, ...)
+    "rescue",        # re-run tasks wedged/stuck, discarding partial progress
+    "probe",         # diagnostic re-run to test a hypothesis, not to fill a cell
+    "tier-change",   # same work resubmitted at a different priority/preemptible tier
+    "backfill",      # recover a metric post-hoc WITHOUT recompute (no new Beaker job)
+    "extend",        # continue a finished run to a longer horizon
+)
+
+_REQUIRED_TRIGGER_KEYS = ("symptom", "cause")
+
+# Compute backends. "none" is for kinds that create no job at all (backfill), so the field
+# stays required and meaningful rather than being left blank.
+PLATFORMS = ("beaker", "hpc", "none")
+
+# Ref types per platform. Beaker identifies a submitted unit by experiment; HPC by W&B sweep
+# (durable) and SLURM job/array ids (recycled, and they age out of sacct — prefer the sweep).
+REF_TYPES = ("beaker_experiment", "wandb_sweep", "slurm_array_job", "slurm_job")
+
+
+def write_intervention(
+    path: Path | str,
+    *,
+    kind: str,
+    platform: str,
+    wandb_group: str,
+    study_root: Path | str,
+    job_refs: list[dict[str, str]] | None = None,
+    supersedes: list[str] | None = None,
+    trigger: dict[str, Any] | None = None,
+    tasks: list[dict[str, Any]] | None = None,
+    deviations: dict[str, Any] | None = None,
+    cost: dict[str, Any] | None = None,
+    produced_by: str = "launch_record.write_intervention",
+) -> dict:
+    """Write a schema-conformant intervention record and return it.
+
+    Args:
+        path: destination JSON, conventionally
+            ``studies/<study>/variants/<variant>/launch_record/beaker_<label>.json``.
+        kind: one of :data:`KINDS`.
+        platform: one of :data:`PLATFORMS` — ``"beaker"``, ``"hpc"``, or ``"none"`` for a
+            kind that submits nothing (backfill).
+        wandb_group: the group these runs belong to — the join key that lets the
+            validator reconcile records against what actually landed in W&B.
+        study_root: ``studies/<study>/``, for the wrapper SHA in ``_meta``.
+        job_refs: typed handles for the submitted unit(s), e.g.
+            ``[{"type": "beaker_experiment", "id": "01K..."}]`` on Beaker or
+            ``[{"type": "wandb_sweep", "id": "abc123"}]`` on HPC. Omit for
+            ``kind="backfill"``, which by definition creates no job. On HPC prefer the
+            W&B sweep id — SLURM ids are recycled and age out of ``sacct``.
+        supersedes: experiment ids (or run ids) this action replaces, so a reader can
+            follow the chain backwards without reading prose.
+        trigger: why this was needed — requires ``symptom`` and ``cause``, plus any
+            ``evidence``. The point is to record the *observation*, not just the verdict.
+        tasks: per-task mapping, typically
+            ``{orig_task, new_task, orig_wandb_run, new_wandb_run}``.
+        deviations: deliberate departures from a plain resubmit — e.g.
+            ``{"fresh_run_ids": True, "renamed_tasks": True,
+               "context_changed": {"priority": "normal", "preemptible": False}}``.
+            Every study-06 intervention made such a choice for a real reason; capturing it
+            here makes the reason auditable instead of buried in a commit message.
+        cost: what the action gave up, e.g. ``{"progress_discarded_steps": {...}}``.
+
+    Raises:
+        ValueError: on an unknown ``kind``/``platform``/ref type, a ``trigger`` missing
+            required keys, or a job-creating kind with no ``job_refs`` (a silent no-op
+            record is worse than no record).
+    """
+    if kind not in KINDS:
+        raise ValueError(f"unknown kind {kind!r}; expected one of {KINDS}")
+    if platform not in PLATFORMS:
+        raise ValueError(f"unknown platform {platform!r}; expected one of {PLATFORMS}")
+
+    trigger = dict(trigger or {})
+    missing = [k for k in _REQUIRED_TRIGGER_KEYS if not trigger.get(k)]
+    if missing:
+        raise ValueError(
+            f"trigger is missing required key(s) {missing}. An intervention record without "
+            "an observed symptom and a cause is not provenance, it is a rumour."
+        )
+
+    job_refs = [dict(r) for r in (job_refs or [])]
+    for r in job_refs:
+        if r.get("type") not in REF_TYPES:
+            raise ValueError(f"job_ref {r!r} has unknown type; expected one of {REF_TYPES}")
+        if not r.get("id"):
+            raise ValueError(f"job_ref {r!r} has no id")
+    if kind != "backfill" and not job_refs:
+        raise ValueError(
+            f"kind={kind!r} submits work, so job_refs must be non-empty "
+            '(beaker: [{"type":"beaker_experiment","id":...}]; '
+            'hpc: [{"type":"wandb_sweep","id":...}])'
+        )
+    if kind == "backfill" and platform != "none":
+        raise ValueError('kind="backfill" submits nothing, so platform must be "none"')
+
+    record = {
+        "_meta": build_meta(produced_by, [wandb_group], study_root=study_root),
+        "kind": kind,
+        "platform": platform,
+        "wandb_group": wandb_group,
+        "job_refs": job_refs,
+        "supersedes": list(supersedes or []),
+        "trigger": trigger,
+        "tasks": list(tasks or []),
+        "deviations": dict(deviations or {}),
+        "cost": dict(cost or {}),
+    }
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, indent=2) + "\n")
+    return record
+
+
+def load_records(launch_record_dir: Path | str) -> list[dict]:
+    """Load every JSON in a ``launch_record/`` dir, newest schema or legacy alike.
+
+    Legacy records (pre-schema, e.g. study 06's hand-written ones) are returned as-is with
+    ``_schema: "legacy"`` so the validator can report them without crashing. Being able to
+    read the old shape is what lets a study adopt this incrementally.
+    """
+    out = []
+    for p in sorted(Path(launch_record_dir).glob("*.json")):
+        try:
+            d = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        d.setdefault("_schema", "current" if "_meta" in d and "kind" in d else "legacy")
+        d["_path"] = str(p)
+        out.append(d)
+    return out
+
+
+def refs_in(records: list[dict], ref_type: str) -> set[str]:
+    """Every id of ``ref_type`` mentioned by any record, current schema or legacy.
+
+    Legacy shapes are handled explicitly rather than guessed at, so a study can adopt the
+    schema without a migration: study 06 used both a flat ``experiment_id`` and a
+    ``parts: [{experiment_id: ...}]`` list, and `launch_hpc.py` wrote nothing at all.
+    """
+    ids: set[str] = set()
+    for r in records:
+        for ref in r.get("job_refs", []) or []:
+            if isinstance(ref, dict) and ref.get("type") == ref_type and ref.get("id"):
+                ids.add(str(ref["id"]))
+        if ref_type != "beaker_experiment":
+            continue
+        # legacy Beaker shapes
+        for key in ("experiment_ids", "experiment_id"):
+            v = r.get(key)
+            if isinstance(v, str):
+                ids.add(v)
+            elif isinstance(v, list):
+                ids.update(x for x in v if isinstance(x, str))
+        for part in r.get("parts", []) or []:
+            if isinstance(part, dict) and isinstance(part.get("experiment_id"), str):
+                ids.add(part["experiment_id"])
+    return ids
+
+
+def experiment_ids_in(records: list[dict]) -> set[str]:
+    """Beaker experiment ids across current and legacy records."""
+    return refs_in(records, "beaker_experiment")

--- a/studies/util/launch_record.py
+++ b/studies/util/launch_record.py
@@ -216,7 +216,8 @@ def load_records(launch_record_dir: Path | str) -> list[dict]:
     for p in sorted(Path(launch_record_dir).glob("*.json")):
         try:
             d = json.loads(p.read_text())
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError) as e:
+            out.append({"_schema": "unreadable", "_path": str(p), "_error": f"{type(e).__name__}: {e}"})
             continue
         d.setdefault("_schema", "current" if "_meta" in d and "kind" in d else "legacy")
         d["_path"] = str(p)

--- a/studies/util/launch_record.py
+++ b/studies/util/launch_record.py
@@ -1,8 +1,7 @@
 """Schema + writer for INTERVENTION launch records (all studies).
 
 WHY THIS EXISTS. A study's *first* launch is well instrumented: the launchers write
-`launch_record/beaker_resumable.json` with a fixed schema and inject the `meta.*` block.
-Everything that happens *afterwards* — resubmitting tasks killed by a bad node, rescuing
+`launch_record/beaker_resumable.json` with a fixed schema, and stamp the portable `meta.*` fields into each W&B run config.
 wedged tasks, probing a failure, changing priority tier, backfilling a lost metric — has
 historically been done with a bespoke script that invented its own JSON shape.
 

--- a/studies/util/validate_provenance.py
+++ b/studies/util/validate_provenance.py
@@ -47,12 +47,16 @@ def check_records_parse(records: list[dict], findings: list) -> None:
     if not records:
         _finding(findings, "ERROR", "records", "no launch_record/*.json found at all")
         return
+    unreadable = [r for r in records if r.get("_schema") == "unreadable"]
+    for r in unreadable:
+        _finding(findings, "ERROR", "records",
+                 f"{Path(r['_path']).name}: unreadable JSON ({r.get('_error')})")
+
     legacy = [Path(r["_path"]).name for r in records if r.get("_schema") == "legacy"]
     if legacy:
         _finding(findings, "WARN", "records",
-                 f"{len(legacy)}/{len(records)} record(s) predate the schema "
-                 f"(no _meta/kind, so no timestamp or provenance): {', '.join(legacy)}")
-    for r in records:
+                 f"{len(legacy)}/{len(records)} record(s) predate the schema (no _meta/kind): "
+                 f"{', '.join(legacy)}")
         if r.get("_schema") != "current":
             continue
         if not r.get("trigger", {}).get("cause"):

--- a/studies/util/validate_provenance.py
+++ b/studies/util/validate_provenance.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Reconcile a variant's launch records against what actually happened.
+
+WHY. Three sources drift independently and nothing checks them against each other:
+
+  1. `launch_record/*.json`  — what we say we launched
+  2. Beaker                  — what experiments actually exist for this W&B group
+  3. `analysis/grid.csv`     — which values are real vs recovered post-hoc
+
+Study 06 drifted on all three at once and none of it was noticed until a manual audit:
+five interventions were launched, 13 Beaker experiments existed where the docs said 8, and
+6 held-out values had been reconstructed post-hoc with that fact recorded only in a skill
+reference and a script docstring — not where a reader of `grid.csv` would ever look.
+
+Every check here exists because that specific drift happened.
+
+    python studies/util/validate_provenance.py studies/06-... --variant mult-d-grid
+    python studies/util/validate_provenance.py studies/06-... --variant mult-d-grid --beaker
+
+ADVISORY BY DEFAULT: exit 0 with findings printed, so it can be wired into a wrap-up
+checklist without blocking anyone mid-flight. `--strict` exits 1 on any finding, for CI or
+for the final study wrap-up where drift should genuinely stop the show. A validator that
+blocks too early just gets bypassed, and a bypassed validator checks nothing.
+
+BEAKER/W&B ARE OPTIONAL: checks 1-2 are fully offline (they read committed files), so the
+common case needs no credentials. `--beaker` adds the live reconciliation.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from launch_record import experiment_ids_in, load_records, refs_in  # noqa: E402
+
+
+def _finding(findings: list, level: str, check: str, msg: str) -> None:
+    findings.append({"level": level, "check": check, "message": msg})
+
+
+def check_records_parse(records: list[dict], findings: list) -> None:
+    """Check 1 — records exist and report which still use the pre-schema shape."""
+    if not records:
+        _finding(findings, "ERROR", "records", "no launch_record/*.json found at all")
+        return
+    legacy = [Path(r["_path"]).name for r in records if r.get("_schema") == "legacy"]
+    if legacy:
+        _finding(findings, "WARN", "records",
+                 f"{len(legacy)}/{len(records)} record(s) predate the schema "
+                 f"(no _meta/kind, so no timestamp or provenance): {', '.join(legacy)}")
+    for r in records:
+        if r.get("_schema") != "current":
+            continue
+        if not r.get("trigger", {}).get("cause"):
+            _finding(findings, "ERROR", "records",
+                     f"{Path(r['_path']).name}: kind={r.get('kind')} has no trigger.cause")
+
+
+def check_backfill_documented(analysis_dir: Path, records: list[dict], findings: list) -> None:
+    """Check 2 — any post-hoc recovered value in grid.csv needs a backfill record.
+
+    This is the check that matters most for anyone *using* the data: a reader must be able
+    to tell natively-logged values from reconstructed ones, and find out how they were
+    reconstructed. In study 06 that link existed only in prose.
+    """
+    grid = analysis_dir / "grid.csv"
+    if not grid.exists():
+        return
+    with grid.open() as f:
+        rows = list(csv.DictReader(f))
+    flag_cols = [c for c in (rows[0].keys() if rows else []) if "backfill" in c.lower()]
+    if not flag_cols:
+        return
+    n_backfilled = sum(1 for r in rows for c in flag_cols if str(r.get(c)).lower() == "true")
+    has_backfill_record = any(r.get("kind") == "backfill" for r in records)
+    if n_backfilled and not has_backfill_record:
+        _finding(findings, "ERROR", "backfill",
+                 f"grid.csv has {n_backfilled} post-hoc recovered value(s) "
+                 f"(column(s): {', '.join(flag_cols)}) but no launch record with "
+                 'kind="backfill" explains how they were produced')
+    elif n_backfilled:
+        _finding(findings, "INFO", "backfill",
+                 f"{n_backfilled} recovered value(s), documented by a backfill record")
+
+
+def check_beaker(wandb_group: str, records: list[dict], workspace: str,
+                 scan_limit: int, findings: list) -> None:
+    """Check 3 — every Beaker experiment for this group appears in some record.
+
+    Catches the failure mode directly: someone launched something and never wrote it down.
+    Scans recent workspace experiments and matches on each task's WANDB_RUN_GROUP env, which
+    is the only reliable link from a Beaker experiment back to a study's W&B group.
+    """
+    try:
+        from beaker import Beaker, Config
+    except ImportError:
+        _finding(findings, "WARN", "beaker", "beaker-py not importable; skipped")
+        return
+    token = os.environ.get("BEAKER_TOKEN")
+    if not token:
+        try:
+            import yaml
+            token = yaml.safe_load(Path.home().joinpath(".beaker/config.yml").read_text())["user_token"]
+        except Exception:
+            _finding(findings, "WARN", "beaker", "no BEAKER_TOKEN and ~/.beaker/config.yml unreadable; skipped")
+            return
+
+    b = Beaker(Config(user_token=token, default_org="ai1", default_workspace=workspace))
+    b._timeout = 60
+    recorded = experiment_ids_in(records)
+
+    found: set[str] = set()
+    for exp in list(b.workspace.experiments(limit=scan_limit)):
+        try:
+            spec = b.experiment.spec(exp.id)
+        except Exception:
+            continue
+        for t in spec.tasks:
+            grp = next((e.value for e in (t.env_vars or []) if e.name == "WANDB_RUN_GROUP"), None)
+            if grp == wandb_group:
+                found.add(exp.id)
+                break
+
+    unrecorded = found - recorded
+    missing = recorded - found
+    if unrecorded:
+        _finding(findings, "ERROR", "beaker",
+                 f"{len(unrecorded)} Beaker experiment(s) target group {wandb_group} but appear "
+                 f"in NO launch record: {', '.join(sorted(unrecorded))}")
+    if missing:
+        _finding(findings, "WARN", "beaker",
+                 f"{len(missing)} recorded experiment(s) not seen in the last {scan_limit} "
+                 f"workspace experiments (may simply be older than the scan window): "
+                 f"{', '.join(sorted(missing))}")
+    if not unrecorded and not missing:
+        _finding(findings, "INFO", "beaker",
+                 f"all {len(found)} Beaker experiment(s) for this group are recorded")
+
+
+def check_wandb_sweeps(wandb_group: str, records: list[dict], project: str, findings: list) -> None:
+    """Check 4 (HPC side) — every W&B sweep feeding this group appears in some record.
+
+    This is the HPC analogue of the Beaker experiment check. On SLURM the durable handle is
+    the **W&B sweep id**: SLURM job ids are recycled and age out of `sacct`, so a sweep id is
+    the only ref that still resolves months later. Harmless for pure-Beaker studies, whose
+    runs simply have no sweep attached.
+    """
+    try:
+        import wandb
+    except ImportError:
+        _finding(findings, "WARN", "wandb", "wandb not importable; skipped")
+        return
+    if not (os.environ.get("WANDB_API_KEY") or Path.home().joinpath(".netrc").exists()):
+        _finding(findings, "WARN", "wandb", "no WANDB_API_KEY and no ~/.netrc; skipped")
+        return
+
+    os.environ.setdefault("WANDB_SILENT", "true")
+    try:
+        api = wandb.Api(timeout=30)
+        runs = list(api.runs(project, filters={"group": wandb_group}, per_page=200))
+    except Exception as e:  # noqa: BLE001
+        _finding(findings, "WARN", "wandb", f"could not query W&B ({type(e).__name__}); skipped")
+        return
+
+    seen: set[str] = set()
+    for r in runs:
+        sweep = getattr(r, "sweep", None)
+        if sweep is not None and getattr(sweep, "id", None):
+            seen.add(str(sweep.id))
+    if not seen:
+        _finding(findings, "INFO", "wandb",
+                 f"{len(runs)} run(s) in group, none attached to a sweep "
+                 "(expected for Beaker-launched studies)")
+        return
+
+    recorded = refs_in(records, "wandb_sweep")
+    unrecorded = seen - recorded
+    if unrecorded:
+        _finding(findings, "ERROR", "wandb",
+                 f"{len(unrecorded)} W&B sweep(s) feed group {wandb_group} but appear in NO "
+                 f"launch record: {', '.join(sorted(unrecorded))}")
+    else:
+        _finding(findings, "INFO", "wandb",
+                 f"all {len(seen)} W&B sweep(s) for this group are recorded")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("study", type=Path, help="path to studies/<study>/")
+    p.add_argument("--variant", required=True)
+    p.add_argument("--wandb-group", default=None,
+                   help="defaults to the group named by the variant's launch records")
+    p.add_argument("--beaker", action="store_true",
+                   help="reconcile Beaker experiments against the records")
+    p.add_argument("--wandb", action="store_true",
+                   help="reconcile W&B sweeps against the records (the HPC/SLURM side)")
+    p.add_argument("--project", default="AIND-disRNN/disrnn_data_scaling",
+                   help="W&B entity/project for --wandb")
+    p.add_argument("--workspace", default="ai1/aind-dynamic-foraging-foundation-model")
+    p.add_argument("--scan-limit", type=int, default=60,
+                   help="how many recent workspace experiments to scan (default 60)")
+    p.add_argument("--strict", action="store_true", help="exit 1 if any ERROR/WARN was found")
+    args = p.parse_args()
+
+    variant_dir = args.study / "variants" / args.variant
+    records = load_records(variant_dir / "launch_record")
+    findings: list = []
+
+    check_records_parse(records, findings)
+    check_backfill_documented(args.study / "analysis", records, findings)
+
+    group = args.wandb_group or next(
+        (r["wandb_group"] for r in records if r.get("wandb_group")), None)
+    if args.beaker or args.wandb:
+        if not group:
+            _finding(findings, "WARN", "reconcile",
+                     "no W&B group known (legacy records omit it); pass --wandb-group")
+        else:
+            if args.beaker:
+                check_beaker(group, records, args.workspace, args.scan_limit, findings)
+            if args.wandb:
+                check_wandb_sweeps(group, records, args.project, findings)
+
+    print(f"provenance check: {args.study.name} / {args.variant}"
+          + (f"  (group {group})" if group else ""))
+    print(f"  {len(records)} launch record(s)")
+    for f in findings:
+        print(f"  [{f['level']:5s}] {f['check']}: {f['message']}")
+    if not findings:
+        print("  no findings")
+
+    bad = [f for f in findings if f["level"] in ("ERROR", "WARN")]
+    if bad and args.strict:
+        print(f"\nFAIL (strict): {len(bad)} finding(s)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/studies/util/validate_provenance.py
+++ b/studies/util/validate_provenance.py
@@ -219,7 +219,13 @@ def main() -> int:
     check_backfill_documented(args.study / "analysis", records, findings)
 
     group = args.wandb_group or next(
-        (r["wandb_group"] for r in records if r.get("wandb_group")), None)
+        (
+            (r.get("wandb_group") or r.get("group"))
+            for r in records
+            if r.get("wandb_group") or r.get("group")
+        ),
+        None,
+    )
     if args.beaker or args.wandb:
         if not group:
             _finding(findings, "WARN", "reconcile",


### PR DESCRIPTION
## Why

Our launchers record the **first** launch and nothing after it. Every follow-up action — resubmit, rescue, probe, tier change, backfill — has been hand-rolled per incident, and that is exactly where provenance gets lost.

Study 06 is the worked example. It ended with five follow-up records in **five different ad-hoc shapes**, none carrying a timestamp:

```
beaker_resumable.json  (launcher)  {chunk_size, mode, n_chunks, n_tasks, parts}
beaker_resubmit20.json (by hand)   {bad_node, parts, reason}
beaker_nanretry1.json  (by hand)   {experiment_id, purpose, tasks}
beaker_rescue1.json    (by hand)   {bad_node, bad_node_hostname, experiment_id, progress_discarded, purpose, tasks}
beaker_tier1.json      (by hand)   {experiment_id, purpose, superseded_experiment, tasks, thrash_evidence}
```

Plus 6 held-out values recovered post-hoc, documented only in a skill reference and a script docstring — not where anyone reading `grid.csv` would look. A manual audit was needed to find that. Interventions are the *surprising* events provenance exists for, and they were the least instrumented part of the system.

Docs alone would not have prevented this: the conventions were known and still produced five schemas, because each intervention was a bespoke script written under time pressure. The fix has to be code.

## What

**`studies/util/launch_record.py`** — `write_intervention()` fixes the shape: `kind`, `platform`, `wandb_group`, `job_refs`, `supersedes`, `trigger`, `tasks`, `deviations`, `cost`. Wraps the existing `_meta.build_meta()`, so a Seattle timestamp and both git SHAs come for free. It **refuses** a record with no `trigger.cause`, an unknown platform/ref type, or a work-submitting kind with no `job_refs`.

The `deviations` block is deliberate: every study-06 intervention made a real choice (fresh vs reused W&B run ids, renamed tasks, changed tier) that was justified in prose but never captured queryably.

**`studies/util/validate_provenance.py`** — reconciles three sources that otherwise drift independently:
1. `launch_record/*.json` — what we say we launched
2. the live backends — Beaker experiments / W&B sweeps actually targeting the group
3. `analysis/grid.csv` — which values are real vs recovered post-hoc

Advisory by default (exit 0, findings printed) so it can sit in a checklist without blocking mid-flight; `--strict` exits 1 for wrap-up and CI. Checks 1–2 are fully offline, so the common case needs no credentials. Legacy pre-schema records are **read, not rejected**, so studies adopt this incrementally.

## Both backends

A study uses both (AGENTS.md §13: GPU → Beaker, CPU → HPC SLURM). They differ only in what identifies a submitted unit, so `job_refs` is a list of *typed* refs rather than a Beaker-shaped `experiment_ids`:

| platform | ref type | note |
|---|---|---|
| `beaker` | `beaker_experiment` | |
| `hpc` | `wandb_sweep` | **preferred — durable** |
| `hpc` | `slurm_array_job` / `slurm_job` | recycled, ages out of `sacct` |
| `none` | *(omit)* | `kind="backfill"` only |

Checking the HPC side turned up something worse than a naming problem: **`launch_hpc.py` writes no launch record at all**, and the `hpc-launch` skill had no provenance section. HPC was *less* instrumented than Beaker, not equally. Both skills now document their own path, and `hpc-launch` flags that interventions must call the helper by hand until that launcher is taught to do it.

## Verified against real data

Run against study 06 (`--beaker --wandb`):

```
5 launch record(s)
[WARN ] records: 5/5 record(s) predate the schema (no _meta/kind, so no timestamp or provenance)
[ERROR] backfill: grid.csv has 6 post-hoc recovered value(s) but no launch record with kind="backfill"
[INFO ] beaker: all 13 Beaker experiment(s) for this group are recorded
[INFO ] wandb: 89 run(s) in group, none attached to a sweep (expected for Beaker-launched studies)
```

Both findings are **true positives**. It also independently confirmed the 13-experiment count, and the HPC/W&B check correctly no-ops on a Beaker-only study. Guard rails tested on both platforms (bad kind, bad platform, unknown ref type, missing cause, work-kind without refs, backfill with a platform).

## Notes for review

- Purely additive: +574 lines, no deletions, no existing behaviour changed.
- Study 06's own records are still legacy — migrating them would clear that ERROR, but it is a separate change I deliberately kept out of infra work.
- Per AGENTS.md §9, **merge with a merge commit — do not squash**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtyqMMF1FdPYsCnU4hpcXM