### PR TITLE
fix(provenance): restore loop in check_records_parse — main is currently broken

### DIFF
--- a/studies/util/validate_provenance.py
+++ b/studies/util/validate_provenance.py
@@ -57,6 +57,11 @@ def check_records_parse(records: list[dict], findings: list) -> None:
         _finding(findings, "WARN", "records",
                  f"{len(legacy)}/{len(records)} record(s) predate the schema (no _meta/kind): "
                  f"{', '.join(legacy)}")
+
+    # Current-schema records must carry a cause; a record that says what was launched but not
+    # why is not provenance. Kept as its own loop -- it applies to every current record, not
+    # only to the ones reached while reporting legacy files.
+    for r in records:
         if r.get("_schema") != "current":
             continue
         if not r.get("trigger", {}).get("cause"):


### PR DESCRIPTION
## main does not compile

`studies/util/validate_provenance.py` on `main` raises at import:

```
File "studies/util/validate_provenance.py", line 61
    continue
    ^^^^^^^^
SyntaxError: 'continue' not properly in loop
```

The module cannot be imported or run at all, so the wrap-up reconciler added in #66 is currently non-functional.

## Cause

A review-fix commit on #66 reworked `check_records_parse`. It added the unreadable-record check (a genuine improvement) and reworded the legacy warning, but removed the `for r in records:` header while leaving its body — including the `continue` — nested inside `if legacy:`.

Two problems, one fatal:
1. `continue` outside a loop → **SyntaxError**.
2. Even had it parsed, the `trigger.cause` check would only have run when legacy records happened to be present, and `r` would have been whatever the preceding `for r in unreadable:` loop left behind.

## Fix

Restores the `trigger.cause` check as its own pass over all records. The reviewer's improvements are kept intact — `load_records` already emits `_schema="unreadable"` with `_error`, so that check works as designed.

## Verification

- compiles (`py_compile`, clean)
- runs against study 06: reports 6 legacy records and the undocumented backfill
- synthetic case confirms all three findings fire independently: unreadable → ERROR, legacy → WARN, current-schema record missing `trigger.cause` → ERROR

Per AGENTS.md §9, **merge with a merge commit — do not squash**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtyqMMF1FdPYsCnU4hpcXM