### PR TITLE
fix(hpc): auto-inject auto_heldout_finetune.output_root so HPC runs log held-out metrics

### DIFF
--- a/code/launch_hpc.py
+++ b/code/launch_hpc.py
@@ -293,6 +293,18 @@ def _inject_lineage_into_command(
             "+meta.slurm_array_task_id='${oc.env:SLURM_ARRAY_TASK_ID,unknown}'",
         ]
     )
+    # HPC has no /results mount (that is the Beaker/Code Ocean container path the
+    # model configs default to), so the end-of-training auto held-out fine-tune
+    # aborts with "[Errno 13] Permission denied: '/results'" and the run logs NO
+    # heldout/* metrics -- silently, as a WARNING, after training has succeeded.
+    # Every HPC sweep needs the override, so inject it here rather than relying on
+    # each sweep YAML to remember (which is how studies 01 and 02 both lost their
+    # held-out metrics). Skip if the sweep already set it explicitly.
+    if not any("auto_heldout_finetune.output_root" in str(c) for c in cmd):
+        cmd.append(
+            "model.training.auto_heldout_finetune.output_root="
+            "'${oc.env:DISRNN_HELDOUT_ROOT,${oc.env:HOME}/outputs/heldout_subject_finetuning}'"
+        )
     sweep_cfg["command"] = cmd
     return sweep_cfg
 


### PR DESCRIPTION
## The bug

Model configs default `auto_heldout_finetune.output_root` to `/results/heldout_subject_finetuning` — the Beaker/Code Ocean container mount. On HPC SLURM that path is unwritable, so the end-of-training held-out fine-tune aborts:

```
training_runner WARNING - Auto held-out fine-tuning failed and will be skipped:
[Errno 13] Permission denied: '/results'
```

It fails **as a WARNING after training succeeds**, so the cell looks complete — early-stops, writes checkpoints, reports `checkpoint/eval_likelihood`. Only `heldout/final/eval_likelihood`, the figure of merit the N×D scaling analyses collect, is silently missing.

## Why a launcher fix rather than another sweep edit

This has bitten **twice**:

| Study | Route | Outcome |
|---|---|---|
| 02 `nxd-3way` | HPC | Hit it; fixed by adding the override to 2 sweep YAMLs (`2bd7ae5`) |
| 01 `nxd-grid` (H=256) | **Beaker** | Fine — `/results` exists there |
| 01 `nxd-h512` (H=512) | HPC | **Hit the identical failure** — its sweeps never carried the override |

The per-sweep fix requires every future sweep author to remember an invisible requirement. Moving it into `_inject_lineage_into_command` means every HPC sweep gets it automatically, next to the `+meta.*` lineage overrides.

## Implementation notes

- Uses OmegaConf env resolvers, not a hardcoded path, so it isn't user/site-specific: `DISRNN_HELDOUT_ROOT` if set, else `$HOME/outputs/heldout_subject_finetuning`.
- Sweeps that already set `output_root` are left untouched (idempotent).
- **Beaker is unaffected** — it doesn't go through `launch_hpc.py` and keeps its native `/results`.

## Evidence

All 9 finished `nxd-h512` cells logged **0** `heldout/*` keys; all 27 `nxd-grid` cells (Beaker) logged **18** each. The 9 affected cells are being backfilled separately from their saved checkpoints (~500 steps each, no retraining).